### PR TITLE
Fixed the broken tryTransportsOnConnectTimeout option and added some events

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ Events:
 
 	Fired when the connection is established and the handshake successful
 	
+- *connecting(transport_type)*
+
+  Fired when a connection is attempted, passing the transport name
+	
+- *connect_failed*
+
+  Fired when the connection timeout occurs after the last connection attempt.
+	This only fires if the `connectTimeout` option is set.
+	If the `tryTransportsOnConnectTimeout` option is set, this only fires once all
+	possible transports have been tried.
+	
 - *message(message)*
 	
 	Fired when a message arrives from the server

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -67,16 +67,17 @@
 					if (!self.connected){
 						self.disconnect();
 						if (self.options.tryTransportsOnConnectTimeout && !self._rememberedTransport){
-							var remainingTransports = [], transports = self.options.transports;
-							for (var i = 0, transport; transport = transports[i]; i++){
-								if (transport != self.transport.type) remainingTransports.push(transport);
-							}
-							if (remainingTransports.length){
-								self.transport = self.getTransport(remainingTransports);
+							if(!self._remainingTransports) self._remainingTransports = self.options.transports.slice(0);
+							var transports = self._remainingTransports;
+							while(transports.length > 0 && transports.splice(0,1)[0] != self.transport.type){}
+							if(transports.length){
+								self.transport = self.getTransport(transports);
 								self.connect();
 							}
 						}
+						if(!self._remainingTransports || self._remainingTransports.length == 0) self.emit('connect_failed');
 					}
+					if(self._remainingTransports && self._remainingTransports.length == 0) delete self._remainingTransports;
 				}, this.options.connectTimeout);
 			}
 		}


### PR DESCRIPTION
Added a 'connecting' event emit on each connection attempt.
Fixed the broken tryTransportsOnConnectTimeout option and added the 'connect_failed' event after the last available transport fails to connect within the timeout.
Perviously, the connect function was re-creating the list of transports each time the timeout was hit, effectively only continually retrying the second transport, and never making it past that.
