### PR TITLE
New message decoder does not work on IE 7

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -40,7 +40,7 @@ io.data.Decoder.prototype = {
    */
   parse: function(){
     for (var l = this.buffer.length; this.i < l; this.i++){
-      var chr = this.buffer[this.i];
+      var chr = this.buffer.charAt(this.i);
       if (this.type === undefined){
         if (chr == ':') return this.error('Data type not specified');
         this.type = '' + chr;
@@ -201,7 +201,7 @@ io.data.decodeMessage = function(msg){
   var anns = {}
     , data;
   for (var i = 0, chr, key, value, l = msg.length; i < l; i++){
-    chr = msg[i];
+    chr = msg.charAt(i);
     if (i === 0 && chr === ':'){
       data = msg.substr(1);
       break;


### PR DESCRIPTION
Stuff like `aString[anIndex]` does not work on Internet Explorer 7. So I've changed those with `aString.charAt(anIndex)`.

The visible effect of this is that on IE7, using flashsocket as the transport, you see in the server logs that it connects succesfully, but the client does not receive (does not decode, actually) any messages, not even the heartbeat, so it disconnects after 15 seconds.
