### PR TITLE
Fixed JSONP-Polling's this._insertAt.parentNode.insertBefore() call (collision with jQuery!)

### DIFF
--- a/lib/transports/jsonp-polling.js
+++ b/lib/transports/jsonp-polling.js
@@ -10,7 +10,7 @@ io.JSONP = [];
 
 JSONPPolling = io.Transport['jsonp-polling'] = function(){
 	io.Transport.XHR.apply(this, arguments);
-	this._insertAt = document.getElementsByTagName('script')[0];
+	this._insertAt = document.getElementsByTagName('head')[0];
 	this._index = io.JSONP.length;
 	io.JSONP.push(this);
 };
@@ -35,7 +35,7 @@ JSONPPolling.prototype._send = function(data){
 		form.action = this._prepareUrl() + '/' + (+new Date) + '/' + this._index;
 		area.name = 'data';
 		form.appendChild(area);
-		this._insertAt.parentNode.insertBefore(form, this._insertAt);
+		this._insertAt.insertBefore(form, null);
 		document.body.appendChild(form);
 
 		this._form = form;
@@ -97,7 +97,7 @@ JSONPPolling.prototype._get = function(){
 	script.onerror = function(){
 		self._onDisconnect();
 	};
-	this._insertAt.parentNode.insertBefore(script, this._insertAt);
+	this._insertAt.insertBefore(script, null);
 	this._script = script;
 };
 

--- a/socket.io.js
+++ b/socket.io.js
@@ -666,7 +666,7 @@ io.JSONP = [];
 
 JSONPPolling = io.Transport['jsonp-polling'] = function(){
 	io.Transport.XHR.apply(this, arguments);
-	this._insertAt = document.getElementsByTagName('script')[0];
+	this._insertAt = document.getElementsByTagName('head')[0];
 	this._index = io.JSONP.length;
 	io.JSONP.push(this);
 };
@@ -691,7 +691,7 @@ JSONPPolling.prototype._send = function(data){
 		form.action = this._prepareUrl() + '/' + (+new Date) + '/' + this._index;
 		area.name = 'data';
 		form.appendChild(area);
-		this._insertAt.parentNode.insertBefore(form, this._insertAt);
+		this._insertAt.insertBefore(form, null);
 		document.body.appendChild(form);
 
 		this._form = form;
@@ -753,7 +753,7 @@ JSONPPolling.prototype._get = function(){
 	script.onerror = function(){
 		self._onDisconnect();
 	};
-	this._insertAt.parentNode.insertBefore(script, this._insertAt);
+	this._insertAt.insertBefore(script, null);
 	this._script = script;
 };
 


### PR DESCRIPTION
I found out that there can be collisions with jQuery's way of fetching data through JSONP: jQuery appends the "head" tag OR appends document.documentElement. In case of appending the documentElement (e.g. the html tag) socket.io tries to get the parentNode of the html-tag which is undefined, so .insertBefore() does not work anymore.

I fixed that so socket.io uses the "head" tag to include JSONP scripts.
