### PR TITLE
Fix for xhr-multipart buffering issue that causes premature onData events to be fired.

### DIFF
--- a/lib/transports/xhr-multipart.js
+++ b/lib/transports/xhr-multipart.js
@@ -20,7 +20,7 @@
 		var self = this;
 		this._xhr = this._request('', 'GET', true);
 		this._xhr.onreadystatechange = function(){
-			if (self._xhr.readyState == 3) self._onData(self._xhr.responseText);
+			if (self._xhr.readyState == 4) self._onData(self._xhr.responseText);
 		};
 		this._xhr.send(null);
 	};

--- a/socket.io.js
+++ b/socket.io.js
@@ -577,7 +577,7 @@ if (typeof window != 'undefined'){
 		var self = this;
 		this._xhr = this._request('', 'GET', true);
 		this._xhr.onreadystatechange = function(){
-			if (self._xhr.readyState == 3) self._onData(self._xhr.responseText);
+			if (self._xhr.readyState == 4) self._onData(self._xhr.responseText);
 		};
 		this._xhr.send(null);
 	};


### PR DESCRIPTION
Currently when a large message is received via xhr-multipart, multiple Transport.prototype._onData events are triggered for the same message, causing JSON.parse errors. This fix ensures the entire message is buffered before triggering the event.
