### PR TITLE
connect_timeout event

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -70,6 +70,7 @@
 				this.connectTimeoutTimer = setTimeout(function(){
 					if (!self.connected){
 						self.disconnect(true);
+						self.emit('connect_timeout',[self.transport.type]);
 						if (self.options.tryTransportsOnConnectTimeout && !self._rememberedTransport){
 							if(!self._remainingTransports) self._remainingTransports = self.options.transports.slice(0);
 							var transports = self._remainingTransports;

--- a/socket.io.js
+++ b/socket.io.js
@@ -854,6 +854,7 @@ if (typeof window != 'undefined'){
 				this.connectTimeoutTimer = setTimeout(function(){
 					if (!self.connected){
 						self.disconnect(true);
+						self.emit('connect_timeout',[self.transport.type]);
 						if (self.options.tryTransportsOnConnectTimeout && !self._rememberedTransport){
 							if(!self._remainingTransports) self._remainingTransports = self.options.transports.slice(0);
 							var transports = self._remainingTransports;


### PR DESCRIPTION
Added a connect_timeout event that fires when the connection is considered failed because of the connectTimeout option.  This allows you to give more feedback to the user  "sorry, couldn't connect".

Note: this doesn't really apply when using the reconnection strategy.
