### PR TITLE
Add .reconnect method

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -165,7 +165,16 @@
 		}
 	};
 	
-	Socket.prototype._onReconnect = function(){
+	Socket.prototype.reconnect = function(){
+		this.abortReconnect();
+		this._onReconnect(true);
+	};
+	
+	Socket.prototype.abortReconnect = function(){
+		if(this.reconnecting && this._reconnectReset) this._reconnectReset();
+	};
+	
+	Socket.prototype._onReconnect = function(immediately){
 		this.reconnecting = true;
 		this.reconnectionAttempts = 0;
 		this.reconnectionDelay = this.options.reconnectionDelay;
@@ -174,7 +183,8 @@
 			, tryTransportsOnConnectTimeout = this.options.tryTransportsOnConnectTimeout
 			, rememberTransport = this.options.rememberTransport;
 		
-		function reset(){
+		var reset = this._reconnectReset = function(){
+			clearTimeout(self.reconnectionTimer);
 			if(self.connected) self.emit('reconnect',[self.transport.type,self.reconnectionAttempts]);
 			self.removeEvent('connect_failed', maybeReconnect).removeEvent('connect', maybeReconnect);
 			delete self.reconnecting;
@@ -182,10 +192,9 @@
 			delete self.reconnectionDelay;
 			delete self.reconnectionTimer;
 			delete self.redoTransports;
+			delete self._reconnectReset;
 			self.options.tryTransportsOnConnectTimeout = tryTransportsOnConnectTimeout;
 			self.options.rememberTransport = rememberTransport;
-			
-			return;
 		};
 		
 		function maybeReconnect(){
@@ -215,7 +224,7 @@
 			}
 		};
 		this.options.tryTransportsOnConnectTimeout = false;
-		this.reconnectionTimer = setTimeout(maybeReconnect, this.reconnectionDelay);
+		this.reconnectionTimer = setTimeout(maybeReconnect, immediately ? 0 : this.reconnectionDelay);
 		
 		this.on('connect', maybeReconnect);
 	};


### PR DESCRIPTION
Add .reconnect() method that aborts the current reconnection procedure if it's happening and restarts the process immediately.

This enables a user to try reconnecting immediately, instead of waiting for the timeout to come around.

Try it out here: http://wompt.com/chat/reconnect_now , then kill your net connection and watch.
