### PR TITLE
Changed socket.onDisconnect to NOT clear the message queue.

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -158,7 +158,6 @@
 		var wasConnected = this.connected;
 		this.connected = false;
 		this.connecting = false;
-		this._queueStack = [];
 		if (wasConnected){
 			this.emit('disconnect');
 			if (this.options.reconnect && !this.reconnecting) this._onReconnect();

--- a/socket.io.js
+++ b/socket.io.js
@@ -942,7 +942,6 @@ if (typeof window != 'undefined'){
 		var wasConnected = this.connected;
 		this.connected = false;
 		this.connecting = false;
-		this._queueStack = [];
 		if (wasConnected){
 			this.emit('disconnect');
 			if (this.options.reconnect && !this.reconnecting) this._onReconnect();


### PR DESCRIPTION
I was having issues with queued messages being cleared when Socket.io was cycling through transports.

```
socket.connect();
socket.send("some message");
```

The message would queued when socket.io was trying flash sockets.  At some point in the process, onDisconnect was called, clearing the queue and the message would never get through.

I can't think of any scenario where you would send a message and want all queued messages cleared on disconnection.. especially since we have reconnection support now.
