### PR TITLE
IE 8 bugfix

### DIFF
--- a/lib/transports/xhr.js
+++ b/lib/transports/xhr.js
@@ -14,8 +14,11 @@
 	XMLHttpRequestCORS = (function(){
 		if (!('XMLHttpRequest' in window)) return false;
 		// CORS feature detection
-		var a = new XMLHttpRequest();
-		return a.withCredentials != undefined;
+		var a;
+		try {
+			a = new XMLHttpRequest();
+		} catch(e){}
+		return a && a.withCredentials != undefined;
 	})(),
 	
 	request = function(xdomain){


### PR DESCRIPTION
This was really odd...  `window.XMLHttpRequest` exists, but it's throwing an error when instantiated `Object doesn't support this property or method`  I've read it has something to do with enabling "Native" XHR support in IE..  I haven't messed with the default IE settings at all.  Anyway I'm on Win 7 Pro, IE8 64bit.  This fixes the issue.  Not sure what other versions this happens to.
