### PR TITLE
bugfix: cross-domain check always returns true when socket.io is running over https

### DIFF
--- a/socket.io.js
+++ b/socket.io.js
@@ -1749,7 +1749,8 @@ if (typeof window != 'undefined'){
    * @api private
    */
   Socket.prototype.isXDomain = function(){
-    var locPort = window.location.port || 80;
+    var defaultPort = window.location.protocol === 'https:' ? 443 : 80;
+    var locPort = window.location.port || defaultPort;
     return this.host !== document.domain || this.options.port != locPort;
   };
   


### PR DESCRIPTION
To reproduce:

var options = {
    secure: true,
    port: 443,
    transports: ['htmlfile']
}

var socket = new io.Socket(null, options);
socket.connect()

// have socket.io server running on port 443 and this will not connect when using IE because 
// Socket.prototype.isXDomain() will return true
