### PR TITLE
emit connect_failed when connect is called while no transports are available (and thus connect failed)

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -169,7 +169,7 @@
         }, this.options.connectTimeout);
       }
     }
-    else self.emit('connect_failed');
+    else this.emit('connect_failed');
     if (fn && typeof fn == 'function') this.once('connect',fn);
     return this;
   };


### PR DESCRIPTION
At the moment, connect_failed is not being emitted when connection has failed due to a lack of transport possibilities.

Eg., if I try to connect with only htmlfile as transport in Chrome, connect_failed will not be emitted while it should. This fix should correct that issue.
