### PR TITLE
auto detect port with https

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -61,7 +61,7 @@
     this.options = {
       secure: false,
       document: document,
-      port: document.location.port || 80,
+      port: document.location.port || (document.location.protocol === 'https:' ? 443 : 80),
       resource: 'socket.io',
       transports: ['websocket', 'flashsocket', 'htmlfile', 'xhr-multipart', 'xhr-polling', 'jsonp-polling'],
       transportOptions: {
@@ -337,7 +337,7 @@
    * @api private
    */
   Socket.prototype.isXDomain = function(){
-    var locPort = window.location.port || 80;
+    var locPort = window.location.port || (document.location.protocol === 'https:' ? 443 : 80);
     return this.host !== document.domain || this.options.port != locPort;
   };
   


### PR DESCRIPTION
Noticed that this was not being done. If you specify a secure connection but no port and you're over https it will still try to use 80.

Thanks for all the great work guys.
