### PR TITLE
Fix a null-dereference bug caused by a callback firing after the socket h

### DIFF
--- a/socket.io.js
+++ b/socket.io.js
@@ -1200,7 +1200,7 @@ if (typeof window != 'undefined'){
     this.xhr = this.request(+ new Date, 'GET');
     this.xhr.onreadystatechange = function(){
       var status;
-      if (self.xhr.readyState == 4){
+      if (self.xhr && self.xhr.readyState == 4){
         self.xhr.onreadystatechange = empty;
         try { status = self.xhr.status; } catch(e){}
         if (status == 200){


### PR DESCRIPTION
## Fix a null-dereference bug caused by a callback firing after the socket has been disconnected.

Hi all - I know this is an old version, hence this bug probably doesn't exist in 0.7, but I'm using tornadio, which doesn't support the 0.7 protocol.

Thanks!

-Mark
