### PR TITLE
Fixed a nasty IE bug where it's unable to parse the unicode characture wh

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -236,16 +236,17 @@
    */
 
   parser.decodePayload = function (data) {
-    if (data[0] == '\ufffd') {
+    // IE doesn't like data[i] for unicode chars, charAt works fine
+    if (data.charAt(0) == '\ufffd') {
       var ret = [];
 
       for (var i = 1, length = ''; i < data.length; i++) {
-        if (data[i] == '\ufffd') {
+        if (data.charAt(i) == '\ufffd') {
           ret.push(parser.decodePacket(data.substr(i + 1).substr(0, length)));
           i += Number(length) + 1;
           length = '';
         } else {
-          length += data[i];
+          length += data.charAt(i);
         }
       }
 


### PR DESCRIPTION
Fixed a nasty IE bug where it's unable to parse the unicode characture when it's
looked up using data[0]. It will return undefined instead the actual char.

But luckly charAt does return the correct characture.

This fixes https://github.com/LearnBoost/socket.io/issues/355
