### PR TITLE
When you disconnect before the connection timeout is called, you will cre

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -241,9 +241,12 @@
       }
 
       connect();
-      if (fn && typeof fn == 'function') {
-        self.once('connect', fn);
-      }
+
+      self.once('connect', function (){
+        clearTimeout(self.connectTimeoutTimer);
+
+        fn && typeof fn == 'function' && fn();
+      });
     });
 
     return this;
@@ -386,7 +389,7 @@
 
   Socket.prototype.onError = function (err) {
     if (err && err.advice) {
-      if (err.advice === 'reconnect') {
+      if (err.advice === 'reconnect' && this.connected) {
         this.disconnect();
         this.reconnect();
       }


### PR DESCRIPTION
When you disconnect before the connection timeout is called, you will create a flood
of unaccepted messages.

Fixes #232
