### PR TITLE
Unspecified secure port defaulting to 80?

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -159,10 +159,11 @@
 
     uuri = io.util.uniqueUri(uri);
 
+    var secure = uri.protocol == 'https';
     var options = {
         host: uri.host
-      , secure: uri.protocol == 'https'
-      , port: uri.port || 80
+      , secure: secure
+      , port: uri.port || (secure?443:80)
     };
     io.util.merge(options, details);
 


### PR DESCRIPTION
Seems like if you don't pass a host to io.connect(), even with the latest fix to get the protocol it was defaulting to port 80, even for https.
