### PR TITLE
don't aggressively set default port to 80

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -1,4 +1,3 @@
-
 /**
  * socket.io
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -162,7 +161,7 @@
     var options = {
         host: uri.host
       , secure: uri.protocol == 'https'
-      , port: uri.port || 80
+      , port: uri.port
     };
     io.util.merge(options, details);
 


### PR DESCRIPTION
don't aggressively set default port to 80. if uri.protocol !== 'http', we get handshake going to https://host:80/socket.io/1/... for page served via https://host, which is wrong
