### PR TITLE
This hack kills the loading indicator in FF

### DIFF
--- a/lib/transports/jsonp-polling.js
+++ b/lib/transports/jsonp-polling.js
@@ -9,7 +9,7 @@
   /**
    * There is a way to hide the loading indicator in Firefox. If you create and
    * remove a iframe it will stop showing the current loading indicator.
-   * Unfortunatly we can't feature detect that and UA sniffing is evil.
+   * Unfortunately we can't feature detect that and UA sniffing is evil.
    *
    * @api private
    */


### PR DESCRIPTION
Kill the loading indicator for JSONP requests in FF
