### PR TITLE
fix for #252 only the last response was send to the server

### DIFF
--- a/lib/transports/jsonp-polling.js
+++ b/lib/transports/jsonp-polling.js
@@ -126,6 +126,8 @@
     } else {
       this.iframe.onload = complete;
     }
+
+    this.socket.setBuffer(true);
   };
   
   /**

--- a/support/test-runner/app.js
+++ b/support/test-runner/app.js
@@ -226,6 +226,23 @@ suite('socket.test.js', function () {
     });
   });
 
+  server('test emmiting multiple events at once to the server', function (io) {
+    io.sockets.on('connection', function (socket) {
+      var messages = [];
+
+      socket.on('print', function (msg) {
+        if (messages.indexOf(msg) >= 0) {
+          throw new Error('duplicate message');
+        }
+
+        messages.push(msg);
+        if (messages.length == 2) {
+          socket.emit('done');
+        }
+      });
+    });
+  });
+
   server('test emitting an event to server', function (io) {
     io.sockets.on('connection', function (socket) {
       socket.on('woot', function () {

--- a/test/socket.test.js
+++ b/test/socket.test.js
@@ -290,6 +290,20 @@
       })
     },
 
+    'test emmiting multiple events at once to the server': function (next) {
+      var socket = create();
+
+      socket.on('connect', function () {
+        socket.emit('print', 'foo');
+        socket.emit('print', 'bar');
+      });
+
+      socket.on('done', function () {
+        socket.disconnect();
+        next();
+      });
+    },
+
     'test emitting an event from server and sending back data': function (next) {
       var socket = create();
 


### PR DESCRIPTION
Fix for a nasty bug in the JSONP transport, if you rapidly send messages using that transport only the last one will get send, so if you send 10, the previous 9 will be canceled. Which is not that good :)

This fixes it, I also converted the test case to test-runner, but the test runner still uses xhr-polling to finish the suite.. So it's quite pointless at this point, but what ever, a extra test never hurts
