### PR TITLE
Added the ability to specify the transport that needs to be tested

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 ALL_TESTS = $(shell find test/ -name '*.test.js')
+TRANSPORT = 'xhr-polling'
 
 run-tests:
 	@npm link --local > /dev/null
@@ -14,7 +15,7 @@ test:
 
 test-acceptance:
 	@npm link --local > /dev/null
-	@node support/test-runner/app
+	@node support/test-runner/app $(TRANSPORT)
 
 build:
 	@node ./bin/builder.js

--- a/support/test-runner/app.js
+++ b/support/test-runner/app.js
@@ -22,6 +22,13 @@ var app = express.createServer();
 var port = 3000;
 
 /**
+ * Transport to test with.
+ */
+
+var args = process.argv.slice(2)
+  , transport = args.length ? args[0] : 'xhr-polling';
+
+/**
  * A map of tests to socket.io ports we're listening on.
  */
 
@@ -92,7 +99,7 @@ var io = sio.listen(app);
 io.configure(function () {
   io.set('browser client handler', handler);
   io.set('transports', [
-      'jsonp-polling'
+      transport
   ]);
 });
 
@@ -116,7 +123,7 @@ function server (name, fn) {
 
   var io = sio.listen(port);
   io.configure(function () {
-    io.set('transports', ['xhr-polling']);
+    io.set('transports', [transport]);
   });
 
   fn(io);


### PR DESCRIPTION
The current situation is less than ideal, as we can fully test all transports that Socket.IO leverages.
With this patch we can do

`make test-acceptance TRANSPORT=websocket`

To run the test suite with the websocket transport.
The only issue is that we still use different ports for the test suite, so we can't test HTMLFile this way.

But what everrrr
