### PR TITLE
We totally missed the `ascii_only` option, so no more filty hacks

### DIFF
--- a/bin/builder.js
+++ b/bin/builder.js
@@ -213,7 +213,7 @@ var builder = module.exports = function () {
         ast = uglify.uglify.ast_mangle(ast);
         ast = uglify.uglify.ast_squeeze(ast);
 
-        code = production + uglify.uglify.gen_code(ast, {ascii_only: true});
+        code = production + uglify.uglify.gen_code(ast, { ascii_only: true });
       }
 
       callback(error, code);


### PR DESCRIPTION
This way the `\ufffd` char will be reserved after code generation
