### PR TITLE
Fixes #268 , without reconenct branch now <3

### DIFF
--- a/lib/transports/xhr-polling.js
+++ b/lib/transports/xhr-polling.js
@@ -32,6 +32,12 @@
   io.util.inherit(XHRPolling, io.Transport.XHR);
 
   /**
+   * Merge the properties from XHR transport
+   */
+
+  io.util.merge(XHRPolling, io.Transport.XHR);
+
+  /**
    * Transport name
    *
    * @api public

--- a/lib/util.js
+++ b/lib/util.js
@@ -252,8 +252,6 @@
   util.inherit = function (ctor, ctor2) {
     function f() {};
     f.prototype = ctor2.prototype;
-
-    util.merge(ctor, ctor2);
     ctor.prototype = new f;
   };
 


### PR DESCRIPTION
The new util.inherit complete breaks all transports because it doesn't merge the properties of the function, only the prototype.

This fixes #268 and a completely broken socket.io
### Apologies for the pull request noise <3 this one is without my new reconnect branch :p
