### PR TITLE
Fix for failing fallback in websockets

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -208,6 +208,8 @@
       );
 
       function connect (transports){
+        if (self.transport) self.transport.clearTimeouts();
+
         self.transport = self.getTransport(transports);
         if (!self.transport) return self.publish('connect_failed');
 


### PR DESCRIPTION
Quick fix until my new reconnect branch is ready.

This makes sure that the websocket connection fallback, without closing the connection.
