### PR TITLE
socket.io fails when no script tags are in the page

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -49,6 +49,13 @@
     this.buffer = [];
     this.doBuffer = false;
 
+    // In cases where a script tag isn't explicity on the page,
+    // create one.
+    if (!document.scripts.length) {
+      document.documentElement.children[0].appendChild(
+        document.createElement('script'));
+    }
+
     if (this.options['sync disconnect on unload'] &&
         (!this.isXDomain() || io.util.ua.hasCORS)) {
       var self = this;


### PR DESCRIPTION
This is a pretty extreme edge case in which socket.io is loaded into a page via some global eval and is unable to find any script tag elements, this would throw an error in several places specifically in handshake.  This patch simply ensures there are script tags otherwise it adds one.
