### PR TITLE
Stop throwing errors when error occures in node

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -92,7 +92,7 @@
      * @api private
      */
 
-    io.EventEmitter = process.EventEmitter;
+    io.EventEmitter = require('./events').EventEmitter;
 
     /**
      * Expose SocketNamespace


### PR DESCRIPTION
Prevents

```
events.js:47
        throw new Error("Uncaught, unspecified 'error' event.");
              ^
Error: Uncaught, unspecified 'error' event.
    at Socket.emit (events.js:47:15)
    at Socket.publish (/Users/V1/Sites/observer/node_modules/socket.io-client/lib/socket.js:97:15)
    at Socket.onError (/Users/V1/Sites/observer/node_modules/socket.io-client/lib/socket.js:413:10)
    at [object Object].<anonymous> (/Users/V1/Sites/observer/node_modules/socket.io-client/lib/socket.js:159:40)
    at /Users/V1/Sites/observer/node_modules/socket.io-client/node_modules/xmlhttprequest/XMLHttpRequest.js:306:9
    at IncomingMessage.<anonymous> (/Users/V1/Sites/observer/node_modules/socket.io-client/node_modules/xmlhttprequest/XMLHttpRequest.js:218:6)
    at IncomingMessage.emit (events.js:81:20)
    at HTTPParser.onMessageComplete (http.js:133:23)
    at Socket.ondata (http.js:1226:22)
    at Socket._onReadable (net.js:683:27)
```

from happening
