### PR TITLE
allow infinite reconnection attempts

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -1,4 +1,3 @@
-
 /**
  * socket.io
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -489,7 +488,8 @@
         return self.reconnectionTimer = setTimeout(maybeReconnect, 1000);
       }
 
-      if (self.reconnectionAttempts++ >= maxAttempts) {
+      if (self.reconnectionAttempts++ >= maxAttempts
+        || maxAttempts === -1) {
         if (!self.redoTransports) {
           self.on('connect_failed', maybeReconnect);
           self.options['try multiple transports'] = true;


### PR DESCRIPTION
allow infinite reconnection attempts, this is useful for an 'eternal' client, something that may go on-line, off-line frequently.
Another solution would be to use a huge number, but a specialized flag seems better (perhaps -1?)
