### PR TITLE
Add .reconnect(immediately) functionality

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -439,15 +439,13 @@
   };
 
   /**
-   * Called upon reconnection.
+   * Called to initiate reconnection.
    *
-   * @api private
+   * @api public
    */
 
   Socket.prototype.reconnect = function (immediately) {
     this.reconnecting = true;
-    this.reconnectionAttempts = 0;
-    this.reconnectionDelay = this.options['reconnection delay'];
 
     var self = this
       , maxAttempts = this.options['max reconnection attempts']
@@ -511,14 +509,16 @@
       }
     };
 
+    // Temporarily override this function so that
+    // further calls try an immediate reconnection
+    this.reconnect = restartReconnectionProcess;
+    restartReconnectionProcess(immediately);
     this.options['try multiple transports'] = false;
-    resetTimer(immediately);
     this.on('connect', maybeReconnect);
 
-    // Temporarily override this function so that
-    // further attempts try an immediate reconnection
-    this.reconnect = function(immediately_){
+    function restartReconnectionProcess(immediately_){
       self.reconnectionAttempts = 0;
+      self.reconnectionDelay = self.options['reconnection delay'];
       resetTimer(immediately_);
     }
 


### PR DESCRIPTION
Allow calling .reconnect() in the middle of the reconnection process.  In that case, the process is reset and reconnection is attempted again immediately.

It's done using a temporary `this.reconnect = function(){...}` that hides the function in the prototype.
