### PR TITLE
Calling socket.disconnect() on a reconnecting socket should end reconnection attempts

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -300,7 +300,7 @@
    */
 
   Socket.prototype.disconnect = function () {
-    if (this.connected) {
+    if (this.connected || this.reconnecting) {
       if (this.open) {
         this.of('').packet({ type: 'disconnect' });
       }
@@ -426,13 +426,15 @@
     this.connecting = false;
     this.open = false;
 
-    if (wasConnected) {
+    if (wasConnected || this.reconnecting) {
       this.transport.close();
       this.transport.clearTimeouts();
       this.publish('disconnect', reason);
 
       if ('booted' != reason && this.options.reconnect && !this.reconnecting) {
         this.reconnect();
+      } else if ('booted' == reason && this.reconnecting) {
+    	this.ceaseReconnecting = true;
       }
     }
   };
@@ -444,6 +446,7 @@
    */
 
   Socket.prototype.reconnect = function () {
+	this.ceaseReconnecting = false;
     this.reconnecting = true;
     this.reconnectionAttempts = 0;
     this.reconnectionDelay = this.options['reconnection delay'];
@@ -481,7 +484,7 @@
         return;
       }
 
-      if (self.connected) {
+      if (self.connected || self.ceaseReconnecting) {
         return reset();
       };
 


### PR DESCRIPTION
If the client disconnects from the server (eg. server falls over) and reconnect = true, the client starts attempting to reconnect to the server. However when you call socket.disconnect() on that client the client continues to reconnect until successful (or reconnect limits reached).

I think the expected behaviour of calling disconnect should be to cease reconnection attempts.

The following few changes fixes this.
