### PR TITLE
Remove closeTimeout wait between transport disconnect and socket.io disconnect

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -101,7 +101,7 @@
    */
 
   Transport.prototype.onDisconnect = function () {
-    if (this.close) this.close();
+    if (this.close && this.open) this.close();
     this.clearTimeouts();
     this.socket.onDisconnect();
     return this;
@@ -196,8 +196,8 @@
     }, this.socket.options['reopen delay']);*/
 
     this.open = false;
-    this.setCloseTimeout();
     this.socket.onClose();
+    this.onDisconnect();
   };
 
   /**


### PR DESCRIPTION
This resolves issues #304 and LearnBoost/socket.io#418, and makes socket.IO behave as it used to in regard to transport disconnection.

When the underlying transport disconnects, immediately inform the socket instead of waiting for the closeTimeout.
