### PR TITLE
Fixes auto-discovery on localhost

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -1,4 +1,3 @@
-
 /**
  * socket.io
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -173,7 +172,7 @@
 
     if (global && global.location) {
       uri.protocol = uri.protocol || global.location.protocol.slice(0, -1);
-      uri.host = uri.host || global.domain;
+      uri.host = uri.host || global.domain || global.location.hostname;
       uri.port = uri.port || global.location.port;
     }
 


### PR DESCRIPTION
I was having trouble with auto-discovery over localhost; `document.domain` is undefined. While this fixes the issue by falling back on `window.location.hostname`, I'm not sure if it's actually a counter-productive change security-wise.

If you can shed some light on `document.domain` instead of/in addition to `window.location.hostname`, please do!
