### PR TITLE
Checking connection state prior to resetting close timeout

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -1,4 +1,3 @@
-
 /**
  * socket.io
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -42,7 +41,13 @@
 
   Transport.prototype.onData = function (data) {
     this.clearCloseTimeout();
-    this.setCloseTimeout();
+    
+    // If the connection in currently open (or in a reopening state) reset the close 
+    // timeout since we have just received data. This check is necessary so
+    // that we don't reset the timeout on an explicitly disconnected connection.
+    if (this.connected || this.connecting || this.reconnecting) {
+      this.setCloseTimeout();
+    }
 
     if (data !== '') {
       // todo: we should only do decodePayload for xhr transports


### PR DESCRIPTION
Adding a check to the close timeout reset so that it won't reset the timeout for a closed connection. This is necessary because the server sends a 'disconnect' message after the client runs a socket.disconnect() which causes the client to reset the close timeout and effectively hang until the the timeout occurs.
