### PR TITLE
Removed decoding of parameters when chunking the query string.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,3 @@
-
 /**
  * socket.io
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -106,7 +105,7 @@
     for (; i < l; ++i) {
       kv = params[i].split('=');
       if (kv[0]) {
-        query[kv[0]] = decodeURIComponent(kv[1]);
+        query[kv[0]] = kv[1];
       }
     }
 


### PR DESCRIPTION
Removed decoding of parameters when chunking the query string. This was used later on to construct the url to post to the socket.io server for connection and if we're adding custom parameters of our own to this url (for example for OAuth authentication) they were being sent decoded, which is wrong.
