### PR TITLE
Clears the timeout from reconnection attempt when there is a successful or failed reconnection

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -1,4 +1,3 @@
-
 /**
  * socket.io
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -463,6 +462,8 @@
         }
         self.publish('reconnect', self.transport.name, self.reconnectionAttempts);
       }
+
+      clearTimeout(self.reconnectionTimer);
 
       self.removeListener('connect_failed', maybeReconnect);
       self.removeListener('connect', maybeReconnect);


### PR DESCRIPTION
Clears the timeout from reconnection attempt when there is a successful or failed reconnection.
This fixes the issue of setTimeout's carrying over from previous reconnection and changing (skipping) values of self.reconnectionDelay in the newer reconnection.
