### PR TITLE
Adds an additional 1 second timeout to the redoTransports logic

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -1,4 +1,3 @@
-
 /**
  * socket.io
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -497,6 +496,7 @@
           self.transport = self.getTransport();
           self.redoTransports = true;
           self.connect();
+          self.reconnectionTimer = setTimeout(maybeReconnect, 1000);
         } else {
           self.publish('reconnect_failed');
           reset();


### PR DESCRIPTION
Adds an additional 1 second timeout to the redoTransports logic, allowing for maybeReconnect to be executed again with self.redoTransports set to true. This allows for reconnect_failed to be emitted.
