### PR TITLE
set withCredentials to true before xhr to fix authentication

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -149,6 +149,7 @@
       var xhr = io.util.request();
 
       xhr.open('GET', url, true);
+      xhr.withCredentials = true;
       xhr.onreadystatechange = function () {
         if (xhr.readyState == 4) {
           xhr.onreadystatechange = empty;


### PR DESCRIPTION
set withCredentials to true before xhr to fix authentication. Bug #333 and server bug https://github.com/LearnBoost/socket.io/issues/625
