### PR TITLE
Partial fix #237 in client and #474 in server for duplicated reconnection in JSONP

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -48,6 +48,7 @@
     this.namespaces = {};
     this.buffer = [];
     this.doBuffer = false;
+    this.lastHandshakeId = null;
 
     if (this.options['sync disconnect on unload'] &&
         (!this.isXDomain() || io.util.ua.hasCORS)) {
@@ -141,6 +142,8 @@
       script.src = url + '&jsonp=' + io.j.length;
       insertAt.parentNode.insertBefore(script, insertAt);
 
+      // store jsonp handshake-callback id
+      this.lastHandshakeId = io.j.length;
       io.j.push(function (data) {
         complete(data);
         script.parentNode.removeChild(script);
@@ -199,6 +202,12 @@
     }
 
     var self = this;
+
+    // clear previous connection-callback to be shure we will not run into
+    // multi-restart issue for JSONP handshake
+    if (self.lastHandshakeId !== null) {
+      io.j[self.lastHandshakeId] = function () {};
+    }
 
     this.handshake(function (sid, heartbeat, close, transports) {
       self.sessionid = sid;


### PR DESCRIPTION
Bug in client: https://github.com/LearnBoost/socket.io-client/issues/237
Bug in server: https://github.com/LearnBoost/socket.io/issues/474

Step to reproduce: https://github.com/LearnBoost/socket.io/issues/474#issuecomment-2833227

This fix for handshake on client. Currently it fixes only JSONP kind of handshake. I'm using v0.8.4 and in this version for my case all handshakes goes through JSONP (comet.site.com <=> site.com).

But newer version of sio-client added for line: https://github.com/LearnBoost/socket.io-client/blob/master/lib/socket.js#L137
part: && !io.util.ua.hasCORS

Now, most of handshakes work through AJAX and maybe only Opera does handshake through JSONP.
And ajax-handshake isn't fixed :(.

There are two way to fix AJAX-part:
1. Disable AJAX-handshake and use only JSONP-handshake
2. Try to implement fix for AJAX-part

I dont know, what you think about it. Please give me feedback. If you think item 2 is preferred, I can try to implement clean solution for it.
