### PR TITLE
Replace (+new Date) with io.time() which does the same thing

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -203,4 +203,13 @@
     return socket.of(uri.path.length > 1 ? uri.path : '');
   };
 
+  /**
+   * Utility to get unix epoch time.  Used mainly to generate a t=# url parameter.
+   *
+   * @api private
+   */
+  io.time = function(){
+    return +new Date();
+  }
+
 })('object' === typeof module ? module.exports : (this.io = {}), this);

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -131,7 +131,7 @@
         , options.host + ':' + options.port
         , options.resource
         , io.protocol
-        , io.util.query(this.options.query, 't=' + +new Date)
+        , io.util.query(this.options.query, 't=' + io.time())
       ].join('/');
 
     if (this.isXDomain() && !io.util.ua.hasCORS) {

--- a/lib/transports/htmlfile.js
+++ b/lib/transports/htmlfile.js
@@ -66,7 +66,7 @@
     iframeC.appendChild(this.iframe);
 
     var self = this
-      , query = io.util.query(this.socket.options.query, 't='+ +new Date);
+      , query = io.util.query(this.socket.options.query, 't=' + io.time());
 
     this.iframe.src = this.prepareUrl() + query;
 

--- a/lib/transports/jsonp-polling.js
+++ b/lib/transports/jsonp-polling.js
@@ -74,7 +74,7 @@
     var self = this
       , query = io.util.query(
              this.socket.options.query
-          , 't='+ (+new Date) + '&i=' + this.index
+          , 't='+ io.time() + '&i=' + this.index
         );
 
     if (!this.form) {
@@ -159,7 +159,7 @@
       , script = document.createElement('script')
       , query = io.util.query(
              this.socket.options.query
-          , 't='+ (+new Date) + '&i=' + this.index
+          , 't=' + io.time() + '&i=' + this.index
         );
 
     if (this.script) {

--- a/lib/transports/xhr.js
+++ b/lib/transports/xhr.js
@@ -149,7 +149,7 @@
 
   XHR.prototype.request = function (method) {
     var req = io.util.request(this.socket.isXDomain())
-      , query = io.util.query(this.socket.options.query, 't=' + +new Date);
+      , query = io.util.query(this.socket.options.query, 't=' + io.time());
 
     req.open(method || 'GET', this.prepareUrl() + query, true);
 


### PR DESCRIPTION
An old JS compressor I used was accidentally turning "'t='+ +new Date" into 't='++new Date so
This fixes that and creates an easy to maintain function instead.
