### PR TITLE
disabled reconnection on error if reconnect option set to false on connect

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -406,7 +406,7 @@
 
   Socket.prototype.onError = function (err) {
     if (err && err.advice) {
-      if (err.advice === 'reconnect' && this.connected) {
+      if (this.options.reconnect && err.advice === 'reconnect' && this.connected) {
         this.disconnect();
         this.reconnect();
       }


### PR DESCRIPTION
If I am setting reconnect to false, means I don't want to reconnect or I am going to handle that situation from outside, above it was trying to reconnect even if reconnect option set to false.
