### PR TITLE
add defer connection flag to options, xhr-polling and jsonp support

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -37,6 +37,7 @@
       , 'sync disconnect on unload': true
       , 'auto connect': true
       , 'flash policy port': 10843
+      , 'defer connection': true
     };
 
     io.util.merge(this.options, options);
@@ -245,7 +246,7 @@
               }
             }, self.options['connect timeout']);
           }
-        });
+        }, self.options['defer connection']);
       }
 
       connect();

--- a/lib/transports/jsonp-polling.js
+++ b/lib/transports/jsonp-polling.js
@@ -209,9 +209,9 @@
    * @api private
    */
 
-  JSONPPolling.prototype.ready = function (socket, fn) {
+  JSONPPolling.prototype.ready = function (socket, fn, deferConnection) {
     var self = this;
-    if (!indicator) return fn.call(this);
+    if (!deferConnection || !indicator) return fn.call(this);
 
     io.util.load(function () {
       fn.call(self);

--- a/lib/transports/xhr-polling.js
+++ b/lib/transports/xhr-polling.js
@@ -132,12 +132,16 @@
    * @api private
    */
 
-  XHRPolling.prototype.ready = function (socket, fn) {
+  XHRPolling.prototype.ready = function (socket, fn, deferConnection) {
     var self = this;
 
-    io.util.defer(function () {
-      fn.call(self);
-    });
+    if(deferConnection) {
+      io.util.defer(function () {
+        fn.call(self);
+      });
+    } else {
+      return fn.call(self);
+    }
   };
 
   /**


### PR DESCRIPTION
The "defer connection" option controls whether any "connection" events will be deferred
to window load (true), or fired as soon as possible after dom ready (false). The
default is true in order to stay compatible.

I read the comments and I understand why the defer feature is there. But for our purposes we were more concerned with initialization time than the browser infinite load issue. So we forked and disabled. This is the first pass at this issue to illustrate what we did in our fork and to gauge interest. If you guys would accept something like this I'll do the work with full compatibility and tests.
