### PR TITLE
Added special handling of arrays in util.merge()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -224,7 +224,10 @@
 
     for (prop in additional) {
       if (additional.hasOwnProperty(prop) && util.indexOf(seen, prop) < 0) {
-        if (typeof target[prop] !== 'object' || !depth) {
+        if (target[prop] instanceof Array || !depth ) { // typeof [] === 'object', so it needs special attention
+          target[prop] = additional[prop];
+          seen.push(additional[prop]);
+        } else if (typeof target[prop] !== 'object' || !depth) {
           target[prop] = additional[prop];
           seen.push(additional[prop]);
         } else {


### PR DESCRIPTION
Arrays were detected as objects and recursively merged. This changes that behavior to overwrite arrays.

This was needed for example when calling `io.connect('', {'transports': ['xhr-polling']});`. This will merge the supplied `transports` option with the default option (being `[websocket,flashsocket,htmlfile,xhr-polling,jsonp-polling]` in my case), resulting in `[xhr-polling,flashsocket,htmlfile,xhr-polling,jsonp-polling]` instead of the expected `[xhr-polling]`.
