### PR TITLE
Fix connections between http/https in IE

### DIFF
--- a/lib/transports/xhr.js
+++ b/lib/transports/xhr.js
@@ -187,7 +187,10 @@
 
   XHR.check = function (socket, xdomain) {
     try {
-      if (io.util.request(xdomain)) {
+      var request = io.util.request(xdomain);
+      var socket_protocol = socket.options.secure ? 'https' : http;
+      var global_protocol = global.location.protocol.split(':')[0];
+      if (request && !(global.XDomainRequest && request instanceof XDomainRequest && socket_protocol != global_protocol)  ) {
         return true;
       }
     } catch(e) {}


### PR DESCRIPTION
Right now, if you try connecting using socket.io over xhr (which includes htmlfile, the suggested IE transport), and it's between http and https, you'll get an "Access denied" error from the cross-domain request.

Let me know what you think of this fix.
