### PR TITLE
fix for broken setCloseTimeout and 'IE+xhr-polling' goes into infinite loop on network disconnection

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -45,7 +45,7 @@
     // If the connection in currently open (or in a reopening state) reset the close 
     // timeout since we have just received data. This check is necessary so
     // that we don't reset the timeout on an explicitly disconnected connection.
-    if (this.connected || this.connecting || this.reconnecting) {
+    if (this.socket.connected || this.socket.connecting || this.socket.reconnecting) {
       this.setCloseTimeout();
     }
 

--- a/lib/transports/xhr-polling.js
+++ b/lib/transports/xhr-polling.js
@@ -88,14 +88,20 @@
 
     function onload () {
       this.onload = empty;
+      this.onerror = empty;
       self.onData(this.responseText);
       self.get();
+    };
+
+    function onerror () {
+      self.onClose();
     };
 
     this.xhr = this.request();
 
     if (global.XDomainRequest && this.xhr instanceof XDomainRequest) {
-      this.xhr.onload = this.xhr.onerror = onload;
+      this.xhr.onload = onload;
+      this.xhr.onerror = onerror;
     } else {
       this.xhr.onreadystatechange = stateChange;
     }
@@ -113,7 +119,7 @@
     io.Transport.XHR.prototype.onClose.call(this);
 
     if (this.xhr) {
-      this.xhr.onreadystatechange = this.xhr.onload = empty;
+      this.xhr.onreadystatechange = this.xhr.onload = this.xhr.onerror = empty;
       try {
         this.xhr.abort();
       } catch(e){}


### PR DESCRIPTION
1)  broken setCloseTimeout : setCloseTimeout is broken in this commit https://github.com/LearnBoost/socket.io-client/commit/172db2035fe10c52e94e5e77054ba0e82f0f7066#lib/transport.js. as all three flags are part of socket.js, it remains undefined all the time so setCloseTimeout never happens, it never dispatch disconnect on timeout and hence no reconnection until it gets error or disconnection from server or browser (like on disabling internet connection, safari on Mac does that)

2) 'IE+xhr-polling' infinite loop : To experience this, put cosole.log inside Transport.prototype.onData. Make socket.io connection on IE with Xhr-polling (you can do it by disabling flashsocket or enabling only xhr-polling). Now disable your internet connection, you can see console flooded with log and cpu usage 100%. Issue is onerror and onload has a same listener onload, which is making recursive call of same function. So in case of error it calls the onload, which does 'self.get' (recursive call to same function), again error, again self.get and so on.
