### PR TITLE
CORS handshake for IE as well

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -149,6 +149,9 @@
 	  var xhr = io.util.request(this.isXDomain());
          
       if (global.XDomainRequest && xhr instanceof XDomainRequest) {
+
+		//this is crazy but it works with IE9 only if you listen to all events         
+		xhr.onprogress  = empty;
         	 
 		xhr.onerror = function () {
    	   		xhr.onload = empty;


### PR DESCRIPTION
CORS is more intuitive as it gives an error if network is disabled, in case of JSONP it doesn't respond at all
