### PR TITLE
added CORS handshake for IE as well

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -150,7 +150,7 @@
       if (global.XDomainRequest && xhr instanceof XDomainRequest) {
 
         //it works with IE9 only if you listen to onprogress event       
-        xhr.onprogress  = empty;
+        xhr.onprogress  = function() {};
         xhr.onerror = function () {
           xhr.onload = empty;
           xhr.onerror = empty;


### PR DESCRIPTION
CORS is more intuitive as it gives an error if network is disabled, in case of JSONP it doesn't respond at all
