### PR TITLE
Added Timeout for JSONP Handshake

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -150,7 +150,7 @@
         script.parentNode.removeChild(script);
       });
     } else {
-     var xhr = io.util.request();
+      var xhr = io.util.request();
 
       xhr.open('GET', url, true);
       xhr.withCredentials = true;


### PR DESCRIPTION
reverted IE CORS handshake and added timeout for following issue
Issue:
When network is disabled, JSONP handshake becomes unresponsive and IO.connect never comes back and it never reconnects when network is enabled again. So added timeout mechanism for JSONP to enable reconnection
