### PR TITLE
#366 Do not rely on Array.prototype.indexOf

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -298,10 +298,7 @@
    */
 
   util.indexOf = function (arr, o, i) {
-    if (Array.prototype.indexOf) {
-      return Array.prototype.indexOf.call(arr, o, i);
-    }
-
+    
     for (var j = arr.length, i = i < 0 ? i + j < 0 ? 0 : i + j : i || 0; 
          i < j && arr[i] !== o; i++) {}
 


### PR DESCRIPTION
Do not rely on Array.prototype.indexOf as it breaks with pages that use the Prototype.js library.
