### PR TITLE
Xhr-based transports didn't close on "not handshaken" error and spammed server with "null".

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -300,7 +300,7 @@
    */
 
   Socket.prototype.disconnect = function () {
-    if (this.connected) {
+    if (this.connected || this.connecting) {
       if (this.open) {
         this.of('').packet({ type: 'disconnect' });
       }
@@ -405,9 +405,11 @@
 
   Socket.prototype.onError = function (err) {
     if (err && err.advice) {
-      if (this.options.reconnect && err.advice === 'reconnect' && this.connected) {
+      if (err.advice === 'reconnect' && (this.connected || this.connecting)) {
         this.disconnect();
-        this.reconnect();
+        if (this.options.reconnect) {
+          this.reconnect();
+        }
       }
     }
 
@@ -421,19 +423,22 @@
    */
 
   Socket.prototype.onDisconnect = function (reason) {
-    var wasConnected = this.connected;
+    var wasConnected = this.connected
+      , wasConnecting = this.connecting;
 
     this.connected = false;
     this.connecting = false;
     this.open = false;
 
-    if (wasConnected) {
+    if (wasConnected || wasConnecting) {
       this.transport.close();
       this.transport.clearTimeouts();
-      this.publish('disconnect', reason);
+      if (wasConnected) {
+        this.publish('disconnect', reason);
 
-      if ('booted' != reason && this.options.reconnect && !this.reconnecting) {
-        this.reconnect();
+        if ('booted' != reason && this.options.reconnect && !this.reconnecting) {
+          this.reconnect();
+        }
       }
     }
   };


### PR DESCRIPTION
Some fixes related to https://github.com/LearnBoost/socket.io/issues/438
At line https://github.com/LearnBoost/socket.io-client/blob/master/lib/socket.js#L221 xhr-based transport starts polling, but server responses with "not handshaken" error.
Socket doesn't handle disconnect as socket.connected flag is not set yet and transport is left open. While transport is open it sends "null" each time it receives data from server in order to keep connection to server. For example, xhr-polling does it in https://github.com/LearnBoost/socket.io-client/blob/master/lib/transports/xhr-polling.js#L71.
This patch closes transport if socket gets error with "reconnect" advice during connecting process.
