### PR TITLE
Fix XHR.check, which was throwing an error and causing non-IE browsers to fall back to JSONP

### DIFF
--- a/lib/transports/xhr.js
+++ b/lib/transports/xhr.js
@@ -187,11 +187,11 @@
 
   XHR.check = function (socket, xdomain) {
     try {
-      var request = io.util.request(xdomain);
-      var uses_xdomainrequest = (global.XDomainRequest && request instanceof XDomainRequest);
-      var socket_protocol = (socket && socket.options && socket.options.secure ? 'https:' : 'http:');
-      var is_cross_protocol = (socket_protocol != global.location.protocol);
-      if (request && !(uses_xdomainrequest && is_cross_protocol)) {
+      var request = io.util.request(xdomain),
+          usesXDomReq = (global.XDomainRequest && request instanceof XDomainRequest),
+          socketProtocol = (socket && socket.options && socket.options.secure ? 'https:' : 'http:'),
+          isXProtocol = (socketProtocol != global.location.protocol);
+      if (request && !(usesXDomReq && isXProtocol)) {
         return true;
       }
     } catch(e) {}


### PR DESCRIPTION
There were a few issues with this commit: https://github.com/LearnBoost/socket.io-client/pull/353/files
e.g. socket and socket.options is not defined when called from XHR.xdomainCheck() and http should be a string, not an object.

This meant that the try catch would throw and JSONP would be used for browsers with a working xdomain XHR implementation, which in turn showed as significantly increased CPU usage on clients, particularly FF.
