### PR TITLE
Implement ActiveX obfuscation for minified dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
       , "stylus": "*"
       , "socket.io": "0.9.0"
       , "socket.io-client": "0.9.0"
+      , "active-x-obfuscator": "0.0.1"
     }
   , "engines": { "node": ">= 0.4.0" }
 }


### PR DESCRIPTION
Some coporate proxys/firewalls (such as Blue Coat) filter out JS files
that contain the string 'ActiveX' in them. This patch alters the Uglify
AST so that all occurences of the string are obfuscated, making
socket.io work in even the most hostile environments : ).

(This only applies to the minified output)
