### PR TITLE
Added dependent module 'active-x-obfuscator'

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "uglify-js": "1.2.5"
       , "ws": "0.4.x"
       , "xmlhttprequest": "1.2.2"
+      , "active-x-obfuscator": "0.0.1"
     }
   , "devDependencies": {
         "expresso": "*"
@@ -29,7 +30,6 @@
       , "stylus": "*"
       , "socket.io": "0.9.1"
       , "socket.io-client": "0.9.1"
-      , "active-x-obfuscator": "0.0.1"
     }
   , "engines": { "node": ">= 0.4.0" }
 }


### PR DESCRIPTION
Throw error when I use in Node.js.

``` sh
$ node -v
v0.6.11
$ node
> require('socket.io-client');
```

Throw error against my expected:

```
node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
Error: Cannot find module 'active-x-obfuscator'
    at Function._resolveFilename (module.js:332:11)
    at Function._load (module.js:279:25)
    at Module.require (module.js:354:17)
    at require (module.js:370:17)
```

I fixed this bug adding `active-x-obfuscator` to dependencies of `package.json`
