### PR TITLE
Transports order of preference

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -249,7 +249,7 @@
         });
       }
 
-      connect();
+      connect(self.options.transports);
 
       self.once('connect', function (){
         clearTimeout(self.connectTimeoutTimer);


### PR DESCRIPTION
When set list of transports as ['xhr-polling', 'jsonp-polling', 'websocket', 'flashsocket'] 
 I wont try first connection to 'xhr-pooling', but connecting to 'websocket'
 From server returned "16698093471053227150:60:256:websocket,flashsocket,xhr-polling,jsonp-polling"  (websocket first)
I think after util.merge() list of transport be broken. 

Small fix solve this problem
