### PR TITLE
NativeJSON conflicting with older prototype.js libraries

### DIFF
--- a/lib/json.js
+++ b/lib/json.js
@@ -1,4 +1,3 @@
-
 /**
  * socket.io
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -12,13 +11,6 @@
 (function (exports, nativeJSON) {
   "use strict";
 
-  // use native JSON if it's available
-  if (nativeJSON && nativeJSON.parse){
-    return exports.JSON = {
-      parse: nativeJSON.parse
-    , stringify: nativeJSON.stringify
-    }
-  }
 
   var JSON = exports.JSON = {};
 


### PR DESCRIPTION
Get rid of using Native JSON because it won't work if sites are using older versions of prototype.js. I know this is a fault of the older prototype.js libraries messing with .toJSON prototypes, but I keep running in to too many of my customers that have the old versions on their site and don't want to FORCE them to upgrade.

Maybe a better solution is to offer an option in socket.io-client to enable/disable using nativeJSON?
