### PR TITLE
Fixing xhr(-polling) under node.js

### DIFF
--- a/lib/transports/xhr.js
+++ b/lib/transports/xhr.js
@@ -185,17 +185,15 @@
    */
 
   XHR.check = function (socket, xdomain) {
+    // if node
+    return true;
+    // end node
+    
     try {
-      var isNode = false;
-      // if node
-      isNode = true;
-      // end node
-      
-      // If called from node, isXProtocol and usedXDomReq is always false
       var request = io.util.request(xdomain),
-          usesXDomReq = !isNode && (global.XDomainRequest && request instanceof XDomainRequest),
+          usesXDomReq = (global.XDomainRequest && request instanceof XDomainRequest),
           socketProtocol = (socket && socket.options && socket.options.secure ? 'https:' : 'http:'),
-          isXProtocol = !isNode && (socketProtocol != global.location.protocol);
+          isXProtocol = (socketProtocol != global.location.protocol);
       if (request && !(usesXDomReq && isXProtocol)) {
         return true;
       }


### PR DESCRIPTION
on nodejs global.location.protocol is not present, so XHR.check always fails.
