### PR TITLE
fix for tranport fallback and multiple connection on reconnect

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -36,6 +36,7 @@
       , 'sync disconnect on unload': true
       , 'auto connect': true
       , 'flash policy port': 10843
+      , orphan:false
     };
 
     io.util.merge(this.options, options);
@@ -47,6 +48,8 @@
     this.namespaces = {};
     this.buffer = [];
     this.doBuffer = false;
+
+    if(this.options.orphan) return;
 
     if (this.options['sync disconnect on unload'] &&
         (!this.isXDomain() || io.util.ua.hasCORS)) {
@@ -93,6 +96,8 @@
    */
 
   Socket.prototype.publish = function () {
+    if(this.options.orphan) return;
+
     this.emit.apply(this, arguments);
 
     var nsp;
@@ -211,7 +216,7 @@
       self.setHeartbeatTimeout();
 
       function connect (transports){
-        if (self.transport) self.transport.clearTimeouts();
+        if (self.transport) self.transport.detach();
 
         self.transport = self.getTransport(transports);
         if (!self.transport) return self.publish('connect_failed');
@@ -423,6 +428,8 @@
    */
 
   Socket.prototype.onError = function (err) {
+    if(this.options.orphan) return;
+
     if (err && err.advice) {
       if (err.advice === 'reconnect' && (this.connected || this.connecting)) {
         this.disconnect();

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -157,6 +157,17 @@
   };
 
   /**
+  * To detach/isolate transport from the associated socket
+  * useful to avoid the effect of this transport when
+  * socket already fallback/connecting/connected to other transport
+  */
+  Transport.prototype.detach = function () {
+    this.socket = new io.Socket({orphan:true, reconnect:false});
+    this.clearTimeouts();
+    this.close();
+  };
+
+  /**
    * Sends a packet
    *
    * @param {Object} packet object.


### PR DESCRIPTION
1) Issue with transport fallback (reproducible on Firefox 11.0 with SquidMan on Mac Lion)
we got some complains that socket.io doesn't connect to some proxy environment where websocket is blocked. Ideally it should fallback to xhr-polling but what happens is :
It tries to connect through websocket, times out, fallback to xhr-polling, gets connected through xhr-polling, now gets an onerror and onclose from websocket which makes socket disconnected and so on.....
This happens because old transport still consist the reference of socket and hence affects the actual connection.
2) Multiple connection on reconnect
As I mentioned above multiple transport shares the same socket reference and hence causes the multiple connection.

Fix:
Detach old transport when going to connect to new transport by changing the socket reference to 'orphan' socket (as per the current design it can't be null) and close the transport.
