### PR TITLE
Patch to fix iPod/iPad/iPhone browser from crashing when resuming on a sites using the websocket transport

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -91,10 +91,23 @@
    * @api public
    */
 
-  WS.prototype.send = function (data) {
-    this.websocket.send(data);
-    return this;
-  };
+  // Do to a bug in the current IDevices browser, we need to wrap the send in a 
+  // setTimeout, when they resume from sleeping the browser will crash if 
+  // we don't allow the browser time to detect the socket has been closed
+  if (io.util.ua.iDevice) {
+    WS.prototype.send = function (data) {
+      var self = this;
+      setTimeout(function() {
+         self.websocket.send(data);
+      },0);
+      return this;
+    };
+  } else {
+    WS.prototype.send = function (data) {
+      this.websocket.send(data);
+      return this;
+    };
+  }
 
   /**
    * Payload

--- a/lib/util.js
+++ b/lib/util.js
@@ -353,4 +353,13 @@
   util.ua.webkit = 'undefined' != typeof navigator
     && /webkit/i.test(navigator.userAgent);
 
+   /**
+   * Detect iPad/iPhone/iPod.
+   *
+   * @api public
+   */
+
+  util.ua.iDevice = 'undefined' != typeof navigator
+      && /iPad|iPhone|iPod/i.test(navigator.userAgent);
+
 })('undefined' != typeof io ? io : module.exports, this);


### PR DESCRIPTION
This will wrap the websocket.send in a setTimeout call only on idevices.  The iDevice will crash because the browser hasn't detected that the socket has closed before the send is triggered.   This will allow the browser to detect that the socket is invalid before attempting to send.
