### PR TITLE
Fix regression due to Pull Request #424 (no reconnect if handshake fail)

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -119,6 +119,7 @@
 
     function complete (data) {
       if (data instanceof Error) {
+        self.connecting = false;
         self.onError(data.message);
       } else {
         fn.apply(null, data.split(':'));
@@ -156,6 +157,7 @@
           if (xhr.status == 200) {
             complete(xhr.responseText);
           } else {
+            self.connecting = false;            
             !self.reconnecting && self.onError(xhr.responseText);
           }
         }


### PR DESCRIPTION
In case the handshake fails (server is down) the connecting flag is marked as true and the reconnect timer doesn't try to reconnect in this case.
The fix is to mark reconnecting false in case the handshake fails.
