### PR TITLE
Fix issues around fallback mechanism and xhr-polling heartbeat

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -270,6 +270,7 @@
 
   Socket.prototype.setHeartbeatTimeout = function () {
     clearTimeout(this.heartbeatTimeoutTimer);
+    if(this.transport && !this.transport.heartbeats()) return;
 
     var self = this;
     this.heartbeatTimeoutTimer = setTimeout(function () {

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -30,6 +30,17 @@
 
   io.util.mixin(Transport, io.EventEmitter);
 
+
+  /**
+   * Indicates whether heartbeats is enabled for this transport
+   *
+   * @api private
+   */
+
+  Transport.prototype.heartbeats = function () {
+    return true;
+  }
+
   /**
    * Handles the response from the server. When a new response is received
    * it will automatically update the timeout, decode the message and

--- a/lib/transports/xhr-polling.js
+++ b/lib/transports/xhr-polling.js
@@ -45,6 +45,15 @@
 
   XHRPolling.prototype.name = 'xhr-polling';
 
+  /**
+   * Indicates whether heartbeats is enabled for this transport
+   *
+   * @api private
+   */
+  XHRPolling.prototype.heartbeats = function () {
+    return false;
+  }
+
   /** 
    * Establish a connection, for iPhone and Android this will be done once the page
    * is loaded.


### PR DESCRIPTION
Issue 1 (Fix reconnect issue when using the fallback mechanism of connect timeout) Flow:
Using multiple transports, and a certain transport fails to connect (first connect try).
After the 'connect timeout' the next transport will be choosen.
This transport is successfully connected and the connection drops after certain time. 
The first transports will be used again and fallback mechanism stops working causing the connection to always fail.
Fix: Choose the right transport that is successful and then when connection disconnects continue using it to reconnect.

Issue 2 ( Fix disconnects when fallback to xhr-polling (heartbeat related)) Flow:
When a certain connect fail and fall backs to xhr-polling and heartbeat is enabled, the xhr-polling is established by disconnects after several seconds due to a heartbeat timeout.
Fix: Since the server is disabling heartbeat to xhr-polling and client disables the heatbeat timeout for it in this case. It may be better for the server to tell the client when heartbeat is disabled and then the client stops the timer.
