### PR TITLE
Fixes XDR from HTTP => HTTPS not falling back properly

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -157,7 +157,7 @@
           if (xhr.status == 200) {
             complete(xhr.responseText);
           } else {
-            self.connecting = false;            
+            self.connecting = false;
             !self.reconnecting && self.onError(xhr.responseText);
           }
         }
@@ -178,7 +178,7 @@
     for (var i = 0, transport; transport = transports[i]; i++) {
       if (io.Transport[transport]
         && io.Transport[transport].check(this)
-        && (!this.isXDomain() || io.Transport[transport].xdomainCheck())) {
+        && (!this.isXDomain() || io.Transport[transport].xdomainCheck(this))) {
         return new io.Transport[transport](this, this.sessionid);
       }
     }
@@ -201,7 +201,7 @@
 
     var self = this;
     self.connecting = true;
-    
+
     this.handshake(function (sid, heartbeat, close, transports) {
       self.sessionid = sid;
       self.closeTimeout = close * 1000;
@@ -366,7 +366,7 @@
     var port = global.location.port ||
       ('https:' == global.location.protocol ? 443 : 80);
 
-    return this.options.host !== global.location.hostname 
+    return this.options.host !== global.location.hostname
       || this.options.port != port;
   };
 

--- a/lib/transports/xhr.js
+++ b/lib/transports/xhr.js
@@ -206,8 +206,8 @@
    * @api public
    */
 
-  XHR.xdomainCheck = function () {
-    return XHR.check(null, true);
+  XHR.xdomainCheck = function (socket) {
+    return XHR.check(socket, true);
   };
 
 })(


### PR DESCRIPTION
We ran into an issue on IE9 where XDR would fail because of cross-protocol limitation of [XDR](http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx). It would return `SCRIPT 5 Access is denied.`. In this situation, it should fallback to JSONP.

After some investigation @mixu and I discovered why it wasn't falling back. `Socket.prototype.getTransport` triggers two checks, one with XHR and one with XDR.

1) XHR.check with XMLHttpRequest.

```
uses_xdomainrequest is false
socket.options.secure is 'https'
socket_protocol is 'https'
global.location.protocol is 'http'
is_cross_protocol is true
returns true
```

2) XHR.check with XDomainRequest.

```
uses_xdomainrequest is true
socket.options.secure is null
socket_protocol is 'http'
global.location.protocol is 'http'
is_cross_protocol is false
return true;
```

Instead the second check should return false and then JSONP would take over. Please take a look and let me know what you think.

P.S. I'm not quite sure how to add a test case for this as I keep getting:

``` bash
uncaught undefined: Error: Cannot find module 'should'
```
