### PR TITLE
`disconnectSync` doesn't send the xhr to the server.

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -345,9 +345,10 @@
   Socket.prototype.disconnectSync = function () {
     // ensure disconnection
     var xhr = io.util.request()
-      , uri = this.resource + '/' + io.protocol + '/' + this.sessionid;
+      , uri = this.options.resource + '/' + io.protocol + '/' + this.sessionid;
 
     xhr.open('GET', uri, true);
+    xhr.send(null);
 
     // handle disconnection immediately
     this.onDisconnect('booted');


### PR DESCRIPTION
Hey, I've been working with this implementation and [gevent-socketio](https://github.com/abourget/gevent-socketio) and I had troubles disconnecting when the client unloaded. I realized that `disconnectSync` wasn't sending the xhr to the server, and also that the uri was malformed with an undefined.

Anyway, this commit fixes that.

Also I was thinking it might be useful to add some parameter to the uri to tel the server that we're disconnecting, something like `/<resource>/<io.protocol>/<session_id>?action=disconnect`
I don't know if that would be useful, what you guys think?
