### PR TITLE
Properly formats disconnectSync URI and sends it

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -179,7 +179,7 @@
     for (var i = 0, transport; transport = transports[i]; i++) {
       if (io.Transport[transport]
         && io.Transport[transport].check(this)
-        && (!this.isXDomain() || io.Transport[transport].xdomainCheck())) {
+        && (!this.isXDomain() || io.Transport[transport].xdomainCheck(this))) {
         return new io.Transport[transport](this, this.sessionid);
       }
     }
@@ -359,10 +359,17 @@
 
   Socket.prototype.disconnectSync = function () {
     // ensure disconnection
-    var xhr = io.util.request()
-      , uri = this.resource + '/' + io.protocol + '/' + this.sessionid;
-
+    var xhr = io.util.request();
+ 	var uri = [
+ 	     'http' + (this.options.secure ? 's' : '') + ':/'
+ 	     , this.options.host + ':' + this.options.port
+ 	     , this.options.resource
+ 	     , io.protocol
+ 	     , this.sessionid
+ 	     ].join('/'); 
+         
     xhr.open('GET', uri, true);
+    xhr.send(null); 
 
     // handle disconnection immediately
     this.onDisconnect('booted');

--- a/lib/transports/htmlfile.js
+++ b/lib/transports/htmlfile.js
@@ -134,11 +134,11 @@
    * @api public
    */
 
-  HTMLFile.check = function () {
+  HTMLFile.check = function (socket) {
     if (typeof window != "undefined" && 'ActiveXObject' in window){
       try {
         var a = new ActiveXObject('htmlfile');
-        return a && io.Transport.XHR.check();
+        return a && io.Transport.XHR.check(socket);
       } catch(e){}
     }
     return false;

--- a/lib/transports/xhr.js
+++ b/lib/transports/xhr.js
@@ -206,8 +206,8 @@
    * @api public
    */
 
-  XHR.xdomainCheck = function () {
-    return XHR.check(null, true);
+  XHR.xdomainCheck = function (socket) {
+    return XHR.check(socket, true);
   };
 
 })(


### PR DESCRIPTION
Also, fixes an issue if using https AND InternetExplorer on crossdomain
sites. In these cases the use of XDomainRequest was not working because
it relied on checks to see if the protocols matched or not. For some
reason, paramaters weren't being passed around and so these checks
failed incorrectly.
