### PR TITLE
Don't try to reconnect after receiving a 403 authorization error

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -157,6 +157,8 @@
 
           if (xhr.status == 200) {
             complete(xhr.responseText);
+          } else if (xhr.status == 403) {
+            self.onError(xhr.responseText);
           } else {
             self.connecting = false;            
             !self.reconnecting && self.onError(xhr.responseText);


### PR DESCRIPTION
Currently, no error event is emitted after a failed authorization. This change will stop reconnecting if a 403 is received.
