### PR TITLE
Fix to set withCredentials property to ture only if xdomain

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -149,7 +149,9 @@
       var xhr = io.util.request();
 
       xhr.open('GET', url, true);
-      xhr.withCredentials = true;
+      if (this.isXDomain()) {
+        xhr.withCredentials = true;
+      }
       xhr.onreadystatechange = function () {
         if (xhr.readyState == 4) {
           xhr.onreadystatechange = empty;


### PR DESCRIPTION
withCredentials property needs to be set to true only when xdomain request. This commit also fixes javascript error on IE6 (Issue #413).
