### PR TITLE
Fixed removeAllListeners to behave expected

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1,4 +1,3 @@
-
 /**
  * socket.io
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -109,11 +108,10 @@
    */
 
   EventEmitter.prototype.removeAllListeners = function (name) {
-    // TODO: enable this when node 0.5 is stable
-    //if (name === undefined) {
-      //this.$events = {};
-      //return this;
-    //}
+    if (name === undefined) {
+      this.$events = {};
+      return this;
+    }
 
     if (this.$events && this.$events[name]) {
       this.$events[name] = null;


### PR DESCRIPTION
I don't know much about history of this, but this should be fixed now.
While comment says the commented will be enabled when node v0.5 is stabled, current node version is v0.8.
