### PR TITLE
XHR post on ie6

### DIFF
--- a/lib/transports/xhr.js
+++ b/lib/transports/xhr.js
@@ -101,16 +101,16 @@
 
     if (global.XDomainRequest && sendXHR instanceof XDomainRequest) {
       sendXHR.onload = sendXHR.onerror = function () {
-        this.onload = empty;
+        sendXHR.onload = empty;
         self.socket.setBuffer(false);
       };
     } else {
       sendXHR.onreadystatechange = function () {
-        if (this.readyState == 4) {
-          this.onreadystatechange = empty;
+        if (sendXHR.readyState == 4) {
+          sendXHR.onreadystatechange = empty;
           self.posting = false;
 
-          if (this.status == 200){
+          if (sendXHR.status == 200){
             self.socket.setBuffer(false);
           } else {
             self.onClose();


### PR DESCRIPTION
On IE6, after first XHR.prototype.post is fired, stateChange() is called but readyState is 'undefined' (NOT int value like 4). 
https://github.com/LearnBoost/socket.io-client/blob/master/lib/transports/xhr.js#L100

Because of this problem, socket.setBuffer(false) is never called, then all client messages except first one are buffered and never flushed.
This pull request is a patch for IE6.

EDIT
IE6 can not handle "this.readyState" when using "this.sendXHR".
Using local variable like https://github.com/LearnBoost/socket.io-client/blob/master/lib/socket.js#L149 works fine.
