### PR TITLE
Support connecting to socket.io from inside a Windows 8 client app (one-line tweak)

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -159,7 +159,7 @@
     return new XMLHttpRequest();
     // end node
 
-    if (xdomain && 'undefined' != typeof XDomainRequest) {
+    if (xdomain && 'undefined' != typeof XDomainRequest && !util.ua.hasCORS) {
       return new XDomainRequest();
     }
 


### PR DESCRIPTION
This makes socket.io.js work on Windows 8 client applications by
default, since:
- Win8 apps are hosted in IE10, which supports CORS, and allows them
  across protocols
- XDomainRequest won't work, as Win8 apps are hosted on a special
  protocol ("ms-appx:") and XDomainRequest disallows cross-protocol
  requests
