### PR TITLE
Add should to devDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
       , "stylus": "*"
       , "socket.io": "0.9.10"
       , "socket.io-client": "0.9.10"
+      , "should": "*"
     }
   , "engines": { "node": ">= 0.4.0" }
 }


### PR DESCRIPTION
Make test will fail without should installed, with should installed it will still fail with `events.test.js add listeners: TypeError: Property 'should' of object a is not a function` and I don't know why that happens.

In test/events.test.js I see a lot of `something.should().eql('something')` and in Should's documentation I see `({ foo: 'bar' }).should.eql({ foo: 'bar' })`... Yxven in IRC suggested the tests might have been written with an older version of should in mind. This pull request is still not passing `make test`.
