### PR TITLE
Make the xhr-polling more stable

### DIFF
--- a/lib/transports/xhr-polling.js
+++ b/lib/transports/xhr-polling.js
@@ -99,12 +99,18 @@
     function onload () {
       this.onload = empty;
       this.onerror = empty;
+      self.retryCounter = 1;
       self.onData(this.responseText);
       self.get();
     };
 
     function onerror () {
-      self.onClose();
+      self.retryCounter ++;
+      if(!self.retryCounter || self.retryCounter > 3) {
+        self.onClose();  
+      } else {
+        self.get();
+      }
     };
 
     this.xhr = this.request();


### PR DESCRIPTION
We use in our system only the xhr-polling transport. I was tracing a number of people who get reconnected. 

I noticed that more then 80% of connection were re-connection. 

This fix solve that problem in case of short internet outage. We are keeping the same session. In case of longest we will go again through authorization process.  
