### PR TITLE
Enable use of 'xhr' transport in Node.js

### DIFF
--- a/lib/transports/xhr.js
+++ b/lib/transports/xhr.js
@@ -190,7 +190,7 @@
       var request = io.util.request(xdomain),
           usesXDomReq = (global.XDomainRequest && request instanceof XDomainRequest),
           socketProtocol = (socket && socket.options && socket.options.secure ? 'https:' : 'http:'),
-          isXProtocol = (socketProtocol != global.location.protocol);
+          isXProtocol = (global.location && socketProtocol != global.location.protocol);
       if (request && !(usesXDomReq && isXProtocol)) {
         return true;
       }


### PR DESCRIPTION
Normally, Socket.io chooses the "ideal" transport in Node.js:
WebSockets. This behavior can lead to unrealistic stress test results
because real-world loads will not be comprised of 100% WebSocket
connections.

The XHR transport itself is fully functional in Node. The transport
check currently fails only because `location` is not defined in the
global scope. By guarding the access of `global.location.protocol`, the
`XHR.check` method can correctly return `true` in Node.

Note that this will **not** change the default behavior in Node clients
to choose the "best available" transport. It only enables the use of a
fully-functional transport when requested.
