### PR TITLE
Added extra option, 'ports', allowing ports to be configured on a per-transport basis

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -37,6 +37,7 @@
       , 'auto connect': true
       , 'flash policy port': 10843
       , 'manualFlush': false
+      , ports: {}
     };
 
     io.util.merge(this.options, options);

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -233,8 +233,15 @@
   Transport.prototype.prepareUrl = function () {
     var options = this.socket.options;
 
+    // Check whether the port is overridden for this transport
+    var port = options.port;
+    if ( 'undefined' != typeof options.ports &&
+         'undefined' != typeof options.ports[this.name] ) {
+        port = options.ports[this.name];
+    }
+
     return this.scheme() + '://'
-      + options.host + ':' + options.port + '/'
+      + options.host + ':' + port + '/'
       + options.resource + '/' + io.protocol
       + '/' + this.name + '/' + this.sessid;
   };


### PR DESCRIPTION
This allows you to talk to a socket.io server through a different port depending on protocol. This is my solution to the various issues I encountered around reverse proxying, multiple ports etc. when attempting to integrate socket.io with a web based game I was working on. This blog post (not mine) talks more about those things: http://blog.mixu.net/2011/08/13/nginx-websockets-ssl-and-socket-io-deployment/ (but I've ignored load balancing and SSL for now)

In my setup, I've got a default port of 80 with overrides for websocket and flashsocket on port 8080. More modern clients with no port blocking can talk websockets. Older browsers, or those on restricted networks, fall back to xhr-polling on port 80, which is reverse proxied to the same server via nginx. It's important to have the handshake on port 80 so that the initial negotiation can take place even if the other ports are blocked.

Usage example:

```
var address = "/endpoint"; // take current host, port etc.
var opts = {
    ports: {
        "websocket": 8080,
        "flashsocket": 8080
    }
};

var socket = io.connect(address, opts);
```
