### PR TITLE
handshake: XHR status 0 is not handled

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -160,6 +160,12 @@
             complete(xhr.responseText);
           } else if (xhr.status == 403) {
             self.onError(xhr.responseText);
+          } else if (xhr.status == 0) {          
+      			var errorObj = {};
+      			errorObj.advice = 'tryConnect';
+      			errorObj.reason = "XHR status: 0. Will try to connect again..";
+      			self.connecting = false;  
+      			!self.reconnecting && self.onError(errorObj);			
           } else {
             self.connecting = false;            
             !self.reconnecting && self.onError(xhr.responseText);
@@ -456,7 +462,11 @@
         if (this.options.reconnect) {
           this.reconnect();
         }
-      }
+      }else if (err.advice === 'tryConnect' && !this.connected && !this.connecting) {        
+		   	 if (this.options.reconnect) {
+				 this.reconnect();
+			}
+		} 
     }
 
     this.publish('error', err && err.reason ? err.reason : err);


### PR DESCRIPTION
The handshake method do not handle the situation when xhr status is equal 0.
This happens when the provided url dont give any response. When it happens also the error message is empty.
I would like to try to reconnect if the socket option 'reconnect' was set to true.

Changed methods:
Socket.prototype.handshake - handle case when xhr status 0
Socket.prototype.onError - handle new error when xhr status == 0
