### PR TITLE
Remove unused instance variable

### DIFF
--- a/lib/transports/xhr.js
+++ b/lib/transports/xhr.js
@@ -26,7 +26,6 @@
     if (!socket) return;
 
     io.Transport.apply(this, arguments);
-    this.sendBuffer = [];
   };
 
   /**


### PR DESCRIPTION
`sendBuffer` is not referenced anywhere else in the source, so it can be
safely removed.

I haven't been able to run the tests, so I urge a maintainer to do so before pulling this in!
