### PR TITLE
Don't try to support AMD loaders in socket.io

### DIFF
--- a/bin/builder.js
+++ b/bin/builder.js
@@ -85,15 +85,13 @@ var baseTransports = {
 
 /**
  * Wrappers for client-side usage.
- * This enables usage in top-level browser window, client-side CommonJS systems and AMD loaders.
+ * This enables usage in top-level browser window and client-side CommonJS systems.
  * If doing a node build for server-side client, this wrapper is NOT included.
  * @api private
  */
 var wrapperPre = "\nvar io = ('undefined' === typeof module ? {} : module.exports);\n(function() {\n";
 
-var wrapperPost = "\nif (typeof define === \"function\" && define.amd) {" +
-                  "\n  define([], function () { return io; });" +
-                  "\n}\n})();";
+var wrapperPost = "\n})();";
 
 
 /**


### PR DESCRIPTION
The AMD loader support that was recently added pollutes things globally.

While undoubtedly useful, this can cause breakage when used with some other libraries, and it is therefore better to let developers do things their own way.

Case in point - #490, which I can reproduce - using Dojo and NowJS together will always break Dojo's `require`.

This PR undoes the relevant changes made by #453.
