### PR TITLE
Fixed issue #473 "Cannot connect from the same client twice"

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -189,7 +189,7 @@
 
     io.util.merge(options, details);
 
-    if (options['force new connection'] || !io.sockets[uuri]) {
+    if (options['force new connection'] || !io.sockets[uuri] || !(io.sockets[uuri].connected || io.sockets[uuri].connecting)) {
       socket = new io.Socket(options);
     }
 


### PR DESCRIPTION
It wouldn't allow connecting from the same client twice even after the client was disconnected.
Now it checks if the previous socket is connected and if not, it will create a new connection.
