### PR TITLE
Attempting to create a connection to an unreachable host takes longer than 'connect timeout' to fail

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -155,6 +155,7 @@
       xhr.onreadystatechange = function () {
         if (xhr.readyState == 4) {
           xhr.onreadystatechange = empty;
+          clearTimeout(xhr.timeout);
 
           if (xhr.status == 200) {
             complete(xhr.responseText);
@@ -166,6 +167,12 @@
           }
         }
       };
+      if (options['connect timeout']) {
+        xhr.timeout = setTimeout(function () {
+          console.error('connection timed out');
+          xhr.abort();
+        }, options['connect timeout']);
+      }
       xhr.send(null);
     }
   };


### PR DESCRIPTION
I expect that when setting the 'connect timeout' option, an attempt to set up a socket.io with an unreachable host (e.g. host is powered down) to fail within that time. If I misunderstood please reject this request with an explanation.
I added a timeout to Socket.prototype.handshake to make sure xhr is not attempted beyond the allowed time.
Sorry for not including a failing test, I haven't been able to get the makefile to run on my (Windows) machine. It's really simple though, just set options['connect timeout'] to 10 seconds and try to connect to a non-running server. The connection fails after 20 seconds.
