### PR TITLE
Disconnect socket once all namespaces are disconnected

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -123,8 +123,7 @@
     if (this.name === '') {
       this.socket.disconnect();
     } else {
-      this.packet({ type: 'disconnect' });
-      this.$emit('disconnect');
+      this.socket.disconnectNamespace(this.name);
     }
 
     return this;

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -87,6 +87,26 @@
   };
 
   /**
+   * Disconnects a namespace, and the socket connection if all namespaces have
+   * been disconnected.
+   *
+   * @api private
+   */
+
+  Socket.prototype.disconnectNamespace = function (name) {
+    if (this.namespaces[name]) {
+      var nsp = this.of(name);
+      nsp.packet({ type: 'disconnect' });
+      nsp.$emit('disconnect');
+      delete this.namespaces[name];
+
+      if (Object.keys(this.namespaces).length === 0) {
+        this.disconnect();
+      }
+    }
+  };
+
+  /**
    * Emits the given event to the Socket and all namespaces
    *
    * @api private
@@ -339,7 +359,7 @@
   Socket.prototype.disconnect = function () {
     if (this.connected || this.connecting) {
       if (this.open) {
-        this.of('').packet({ type: 'disconnect' });
+        this.packet({ type: 'disconnect' });
       }
 
       // handle disconnection immediately
@@ -440,7 +460,9 @@
    */
 
   Socket.prototype.onPacket = function (packet) {
-    this.of(packet.endpoint).onPacket(packet);
+    if (this.namespaces[packet.endpoint]) {
+      this.of(packet.endpoint).onPacket(packet);
+    }
   };
 
   /**


### PR DESCRIPTION
In order to support this, only user requested namespaces are registered.

This will also fix an issue where explicitly disconnected namespaces
don't stop receiving events through Socket#publish().
