### PR TITLE
Issue #489

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -477,8 +477,10 @@
     this.open = false;
 
     if (wasConnected || wasConnecting) {
-      this.transport.close();
-      this.transport.clearTimeouts();
+      if (this.transport) {
+        this.transport.close();
+        this.transport.clearTimeouts();
+      }
       if (wasConnected) {
         this.publish('disconnect', reason);
 


### PR DESCRIPTION
Check transport before closing. It may not be set if a disconnect occurs before a handshake is completed. Issue #489.
