### PR TITLE
update xmlhttprequest dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   , "dependencies": {
         "uglify-js": "1.2.5"
       , "ws": "0.4.x"
-      , "xmlhttprequest": "1.4.2"
+      , "xmlhttprequest": "1.5.0"
       , "active-x-obfuscator": "0.0.1"
     }
   , "devDependencies": {


### PR DESCRIPTION
I really wish you could bump to xmlhttprequest version. `1.5.0` has a `setDisableHeaderCheck`` that allows me to pass a cookie in there.. This allows me to monkeypatch xmlhttprequest to use the cookie I want so I can authenticate my client as shown in this gist:

https://gist.github.com/4087861

thank you very much
