### PR TITLE
Update lib/transports/jsonp-polling.js - IE6 error popup while on https;

### DIFF
--- a/lib/transports/jsonp-polling.js
+++ b/lib/transports/jsonp-polling.js
@@ -1,4 +1,3 @@
-
 /**
  * socket.io
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
@@ -113,10 +112,11 @@
 
       try {
         // ie6 dynamic iframes with target="" support (thanks Chris Lambacher)
-        iframe = document.createElement('<iframe name="'+ self.iframeId +'">');
+        iframe = document.createElement('<iframe src="javascript:0" name="'+ self.iframeId +'">');
       } catch (e) {
         iframe = document.createElement('iframe');
         iframe.name = self.iframeId;
+        iframe.src = "javascript:0";
       }
 
       iframe.id = self.iframeId;
@@ -181,6 +181,7 @@
     if (indicator) {
       setTimeout(function () {
         var iframe = document.createElement('iframe');
+        iframe.src = "javascript:0";
         document.body.appendChild(iframe);
         document.body.removeChild(iframe);
       }, 100);


### PR DESCRIPTION
Hello!

I was having some issues with the jsonp fallback, while on Internet Explorer 6. 
This was happening when the origin request was secure (https), IE6 kept displaying
the message "This page contains both secure and nonsecure items...".

With a little research I found this commit in another project, whose the main
purpose was to fix this error: https://github.com/cowboy/jquery-bbq/commit/f276cef0597990c8c8933eb71a288b5d3fb10d05

I've forked, updated socket.io-client code with the fix and it worked.

Here's my contribution.
