### PR TITLE
Calling mayReconnect one more time to allow reconnect_failed to be fired

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -551,6 +551,8 @@
           self.transport = self.getTransport();
           self.redoTransports = true;
           self.connect();
+          self.publish('reconnecting', self.reconnectionDelay, self.reconnectionAttempts);
+          self.reconnectionTimer = setTimeout(maybeReconnect, self.reconnectionDelay);
         } else {
           self.publish('reconnect_failed');
           reset();


### PR DESCRIPTION
As per @robbrit comment at https://github.com/LearnBoost/socket.io/issues/652#issuecomment-6250270, firing 'reconnecting' event and looping one more time over maybeReconnect will properly fire the 'reconnect_failed' event.

All the tests done locally show the patch works properly on client version 0.9.11.

Additionally, it will also fix https://github.com/LearnBoost/socket.io-client/issues/472 and possibly https://github.com/LearnBoost/socket.io-client/issues/311.
