### PR TITLE
Update socket.js

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -363,7 +363,6 @@
       , this.options.host + ':' + this.options.port
       , this.options.resource
       , io.protocol
-      , ''
       , this.sessionid
     ].join('/') + '/?disconnect=1';
 


### PR DESCRIPTION
If "sync disconnect on unload" is set to true I was getting a lot of errors like these: 
 -> "XMLHttpRequest cannot load http://s1.test.com/socket.io/1//L1VtwrMiikmwXVoEQF2o/?disconnect=1. Origin http://www.teste2.com is not allowed by Access-Control-Allow-Origin."

I found out that this was being caused by the extra slash right before the session_id on the url! 

This fix removes that extra space on the uri formation (Why is it there?)

Best Regards
