### PR TITLE
Subscribes before calling onopen (1.0)

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -67,11 +67,11 @@ Socket.prototype.open =
 Socket.prototype.connect = function(){
   var io = this.io;
   io.open(); // ensure open
-  if ('open' == this.io.readyState) this.onopen();
   this.subs = [
     on(io, 'open', bind(this, 'onopen')),
     on(io, 'error', bind(this, 'onerror'))
   ];
+  if ('open' == this.io.readyState) this.onopen();
 };
 
 /**


### PR DESCRIPTION
Errors happen when you open another new connection with a namespace after establishing the connection.

Uncaught TypeError: Cannot call method 'push' of undefined 
Uncaught TypeError: Cannot read property 'length' of undefined 
