### PR TITLE
Fix reconnection never happen (1.0)

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -130,10 +130,10 @@ Manager.prototype.timeout = function(v){
 
 Manager.prototype.open =
 Manager.prototype.connect = function(fn){
-  if (~this.readyState.indexOf('open') && !this.reconnecting) return this;
+  if (~this.readyState.indexOf('open')) return this;
 
-  if (this.reconnecting) {
-    this.engine.open();
+  if ('opening' != this.engine.readyState && 'open' != this.engine.readyState) {
+    this.engine.open(); // ensure open
   }
 
   var socket = this.engine;
@@ -296,6 +296,7 @@ Manager.prototype.close =
 Manager.prototype.disconnect = function(){
   this.skipReconnect = true;
   this.cleanup();
+  this.readyState = 'closed';
   this.engine.close();
 };
 
@@ -307,6 +308,7 @@ Manager.prototype.disconnect = function(){
 
 Manager.prototype.onclose = function(){
   this.cleanup();
+  this.readyState = 'closed';
   if (!this.skipReconnect) {
     this.reconnect();
   }


### PR DESCRIPTION
`readyState` remains `open` when disconnecting, so that you can't reconnect the `Manager` instance again both manually and automatically.
Additionally we have to reopen the socket of engine.io.

a related issue: #545
