### PR TITLE
Consider the case when packet.id is 0 (v1.0)

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -220,7 +220,7 @@ Socket.prototype.onevent = function(packet){
   var args = packet.data || [];
   debug('emitting event %j', args);
 
-  if (packet.id) {
+  if (null != packet.id) {
     debug('attaching ack callback to event');
     args.push(this.ack(packet.id));
   }


### PR DESCRIPTION
Related commit: https://github.com/LearnBoost/socket.io-protocol/commit/344323a314cee564992ec853a0dfc7a23d581ccc
