### PR TITLE
Fix to manage namespace disconnection and reconnection

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -26,6 +26,7 @@
     this.json = new Flag(this, 'json');
     this.ackPackets = 0;
     this.acks = {};
+	  this.connected = false;
   };
 
   /**
@@ -158,6 +159,7 @@
         } else {
           this.$emit('disconnect', packet.reason);
         }
+	      this.connected = false;
         break;
 
       case 'message':

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -75,13 +75,19 @@
    */
 
   Socket.prototype.of = function (name) {
-    if (!this.namespaces[name]) {
+	  if (!this.namespaces[name]) {
       this.namespaces[name] = new io.SocketNamespace(this, name);
 
       if (name !== '') {
-        this.namespaces[name].packet({ type: 'connect' });
+	      this.namespaces[name].connected = true;
+	      this.namespaces[name].packet({ type: 'connect' });
       }
-    }
+	  } else {
+		  if (!this.namespaces[name].connected) {
+			  this.namespaces[name].connected = true;
+			  this.namespaces[name].packet({ type: 'connect' });
+		  }
+	  }
 
     return this.namespaces[name];
   };
@@ -161,7 +167,7 @@
           } else if (xhr.status == 403) {
             self.onError(xhr.responseText);
           } else {
-            self.connecting = false;            
+            self.connecting = false;
             !self.reconnecting && self.onError(xhr.responseText);
           }
         }
@@ -205,7 +211,7 @@
 
     var self = this;
     self.connecting = true;
-    
+
     this.handshake(function (sid, heartbeat, close, transports) {
       self.sessionid = sid;
       self.closeTimeout = close * 1000;
@@ -327,7 +333,7 @@
     this.transport.payload(this.buffer);
     this.buffer = [];
   };
-  
+
 
   /**
    * Disconnect the established connect.
@@ -390,7 +396,7 @@
     var port = global.location.port ||
       ('https:' == global.location.protocol ? 443 : 80);
 
-    return this.options.host !== global.location.hostname 
+    return this.options.host !== global.location.hostname
       || this.options.port != port;
   };
 


### PR DESCRIPTION
Hi,

I was struggling to manage the namespace client disconnection in the application that we are working. 
I realised that when the client disconnect from a namespace, after if I tried to connect again to the same namespace, it didn't receive the messages from the server, at least if the client reconnected the socket to the same namespace some seconds after he had disconnected it.

After debugging the code for awhile, I found this fix.

This pull request corresponds to another pull request to socket.io that I've done: [#1296](https://github.com/LearnBoost/socket.io/issues/1296)
