### PR TITLE
Avoid empty error event when responseText is empty

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -161,8 +161,9 @@
           } else if (xhr.status == 403) {
             self.onError(xhr.responseText);
           } else {
-            self.connecting = false;            
-            !self.reconnecting && self.onError(xhr.responseText);
+            self.connecting = false;
+            var msg = xhr.responseText || xhr.statusText || xhr.status;
+            !self.reconnecting && self.onError(msg);
           }
         }
       };


### PR DESCRIPTION
Using statusText or status when responseText is empty in onreadystatechange
