### PR TITLE
Allow cookies to be sent in XMLHttpRequest handshake; see https://github...

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -149,6 +149,12 @@
       var xhr = io.util.request();
 
       xhr.open('GET', url, true);
+      
+      if (this.options.cookie) {
+        xhr.setDisableHeaderCheck(true);
+        xhr.setRequestHeader('Cookie', this.options.cookie);
+      }
+
       if (this.isXDomain()) {
         xhr.withCredentials = true;
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   , "dependencies": {
         "uglify-js": "1.2.5"
       , "ws": "0.4.x"
-      , "xmlhttprequest": "1.4.2"
+      , "xmlhttprequest": "1.6.0"
       , "active-x-obfuscator": "0.0.1"
     }
   , "devDependencies": {


### PR DESCRIPTION
....com/LearnBoost/socket.io-client/issues/344

See: Issue #344

With these changes, can now send a cookie with the XHR handshake, allowing for persisting a user session.

Note about dependency upgrade:
Had to update XMLHttpRequest module to 1.6.0, to be able to disable forbidden headers in an XHR request.
