### PR TITLE
Addresses Issue detailed #489

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -274,7 +274,7 @@
 
   Socket.prototype.setHeartbeatTimeout = function () {
     clearTimeout(this.heartbeatTimeoutTimer);
-    if(!this.transport || (this.transport && !this.transport.heartbeats())) return;
+    if(!this.transport || !this.transport.heartbeats()) return;
 
     var self = this;
     this.heartbeatTimeoutTimer = setTimeout(function () {


### PR DESCRIPTION
The root cause of this error is that the heartbeat time-out gets set in the first place when transport is undefined.

This is due to an error in the way the condition is being checked. This PR addresses this issue and is hopefully a better fit for the fix and can get merged.

Reference to open issue relating to this;

[Issue #489](https://github.com/LearnBoost/socket.io-client/issues/489)
