### PR TITLE
Should check packet.id for non-null, not 0

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -220,7 +220,7 @@ Socket.prototype.onevent = function(packet){
   var args = packet.data || [];
   debug('emitting event %j', args);
 
-  if (packet.id) {
+  if (null != packet.id) {
     debug('attaching ack callback to event');
     args.push(this.ack(packet.id));
   }


### PR DESCRIPTION
Like the server does!!! (line 288 in socket.io/lib/socket.js)

Question based on engine.io-protocol documentation:

Is there an underlying problem with the packet.id being 0? Should an ack message be sent to the client first?

Inspiration for checking for non-null instead of 0 was seeing that the server code did it -- but maybe there is a deeper problem we should think about?
