### PR TITLE
Remove require fs in lib/index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,17 +51,6 @@ function lookup(uri, opts){
 }
 
 /**
- * Expose standalone client source.
- *
- * @api public
- */
-
-if ('undefined' == typeof window) {
-  var read = require('fs').readFileSync;
-  exports.source = read(__dirname + '/../socket.io.js');
-}
-
-/**
  * Protocol version.
  *
  * @api public


### PR DESCRIPTION
This removes the statement where fs module is required. fs module is not available in browser environment and it will cause an error when called
