### PR TITLE
fixed zuul redirect bug

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -16,28 +16,31 @@ module.exports = parse;
  * URL parser.
  *
  * @param {String} url
+ * @param {Object} An object meant to mimic window.location.
+ *                 Defaults to window.location.
  * @api public
  */
 
-function parse(uri){
+function parse(uri, loc){
   var obj = uri;
+  // default to window.location
+  var loc = loc || location;
 
-  // default to window's location
-  if (null == uri) uri = location.protocol + '//' + location.host;
+  if (null == uri) uri = loc.protocol + '//' + loc.host;
 
   // parse string
   if ('string' == typeof uri) {
     if ('/' == uri.charAt(0)) {
-      if ('undefined' != typeof location) {
-        uri = location.hostname + uri;
+      if ('undefined' != typeof loc) {
+        uri = loc.hostname + uri;
       }
     }
 
     // allow for `localhost:3000`
     if (!/^(https?|wss?):\/\//.test(uri)) {
       debug('protocol-less url %s', uri);
-      if ('undefined' != typeof location) {
-        uri = location.protocol + '//' + uri;
+      if ('undefined' != typeof loc) {
+        uri = loc.protocol + '//' + uri;
       } else {
         uri = 'https://' + uri;
       }

--- a/test/url.js
+++ b/test/url.js
@@ -1,6 +1,6 @@
 
 var old = global.location;
-var loc = global.location = {};
+var loc = {};
 var url = require('../lib/url');
 var expect = require('expect.js');
 
@@ -9,14 +9,14 @@ describe('url', function(){
   it('works with relative paths', function(){
     loc.hostname = 'woot.com';
     loc.protocol = 'https:';
-    var parsed = url('/test');
+    var parsed = url('/test', loc);
     expect(parsed.hostname).to.be('woot.com');
     expect(parsed.protocol).to.be('https:');
   });
 
   it('works with no protocol', function(){
     loc.protocol = 'http:';
-    var parsed = url('localhost:3000');
+    var parsed = url('localhost:3000', loc);
     expect(parsed.protocol).to.be('http:');
     expect(parsed.hostname).to.be('localhost');
     expect(parsed.host).to.be('localhost:3000');


### PR DESCRIPTION
Attempting to use zuul resulting in a redirect to /[object%20Object]. This diff fixes that bug by adding another parameter to url to specify an override for window.location.
