### PR TITLE
Test against Node 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: node_js
 node_js:
+  - "0.8"
   - "0.10"
+  - "0.11"
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: "0.11"
 
 notifications:
   irc: "irc.freenode.org#socket.io"


### PR DESCRIPTION
This makes the same changes to Socket.IO's .travis.yml in PR https://github.com/LearnBoost/socket.io/pull/1425.
It tests against Node 0.8 and 0.11 on Travis CI, and allows the Node 0.11 job to fail without failing the whole build. The `fast_finish: true` line allows the build to be marked as finished without waiting for the Node 0.11 job to finish.
