### PR TITLE
Emit reconnect event, plus basic tests

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -378,17 +378,16 @@ Manager.prototype.reconnect = function(){
 
     this.reconnecting = true;
     var timer = setTimeout(function(){
-      debug('attempting reconnect');
+      debug('attempting reconnect (%d out of %d)', this.attempts, this._reconnectionAttempts);
+      self.once('open', function() {
+        debug('reconnect success');
+        self.onreconnect();
+      });
       self.open(function(err){
-        if (err) {
-          debug('reconnect attempt error');
-          self.reconnecting = false;
-          self.reconnect();
-          self.emit('reconnect_error', err.data);
-        } else {
-          debug('reconnect success');
-          self.onreconnect();
-        }
+        debug('reconnect attempt error');
+        self.reconnecting = false;
+        self.reconnect();
+        self.emit('reconnect_error', err.data);
       });
     }, delay);
 

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -2,7 +2,7 @@
 // this is a test server to support tests which make requests
 
 var io = require('socket.io');
-var server = io(process.env.ZUUL_PORT);
+var server = io(process.env.ZUUL_PORT, {pingInterval: 800, pingTimeout: 2000});
 var expect = require('expect.js');
 
 server.on('connection', function(socket){
@@ -91,5 +91,15 @@ server.on('connection', function(socket){
   socket.on('getbin', function() {
     buf = new Buffer('asdfasdf', 'utf8');
     socket.emit('takebin', buf);
+  });
+
+  // reconnect test
+  socket.on('reconn', function() {
+    socket.conn.sendPacket = function() {};
+  });
+
+  // connect_timeout, reconnect_error, reconnect_failed test
+  socket.on('timeout_fail', function() {
+    Object.getPrototypeOf(socket.conn).sendPacket = function() {};
   });
 });


### PR DESCRIPTION
Should address issues #582, #627.

Resolution to getting reconnect to emit could alternatively be solved by getting socket.open() to call the callback regardless of error, as suggested in pull request #635.
