### PR TITLE
Let uri be optional when adding options for lookup()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,12 @@ var cache = exports.managers = {};
  * @api public
  */
 
-function lookup(uri, opts){
+function lookup(uri, opts) {
+  if (typeof uri == 'object') {
+    opts = uri;
+    uri = undefined;
+  }
+
   opts = opts || {};
 
   var parsed = url(uri);


### PR DESCRIPTION
So someone can go

```
var io = require('socket.io-client');
var socket = io({'reconnectionAttempts': 2});
```

and not wonder why his options didn't propagate.
