### PR TITLE
Allow alternate websocket implementations

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -53,11 +53,13 @@
   WS.prototype.open = function () {
     var query = io.util.query(this.socket.options.query)
       , self = this
-      , Socket
+      , Socket = this.socket.options.webSocketImpl
 
-    // if node
-    Socket = require('ws');
-    // end node
+    if (!Socket) {
+      // if node
+      Socket = require('ws');
+      // end node
+    }
 
     if (!Socket) {
       Socket = global.MozWebSocket || global.WebSocket;


### PR DESCRIPTION
I was trying to use the socket.io-client to test a socket.io server and I wanted to be able to tweak exact behavior on the underlying WebSocket implementation.  Because socket.io-client hardcoded exactly which WebSocket implementations were used, it was hard/impossible to achive what I was wanted.
