### PR TITLE
Allow providing extra headers in the handshake request

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -166,6 +166,16 @@
           }
         }
       };
+
+      // Include any customer headers requested for the handshake
+      if (options.handshakeHeaders) {
+        for (var header in options.handshakeHeaders) {
+          if (options.handshakeHeaders.hasOwnProperty(header)) {
+              xhr.setRequestHeader(header, options.handshakeHeaders[header]);
+          }
+        }
+      }
+
       xhr.send(null);
     }
   };


### PR DESCRIPTION
I was trying to test a socket.io server with the socket.io-client module when I wanted to provide some extra headers in the handshake request (for authentication).  The attached change worked for my situation.
