### PR TITLE
Enable reconnection by default

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -34,7 +34,7 @@ function Manager(uri, opts){
   this.nsps = {};
   this.subs = [];
   this.opts = opts;
-  this.reconnection(opts.reconnection);
+  this.reconnection(opts.reconnection !== false);
   this.reconnectionAttempts(opts.reconnectionAttempts || Infinity);
   this.reconnectionDelay(opts.reconnectionDelay || 1000);
   this.reconnectionDelayMax(opts.reconnectionDelayMax || 5000);
@@ -350,7 +350,7 @@ Manager.prototype.onclose = function(reason){
   this.cleanup();
   this.readyState = 'closed';
   this.emit('close', reason);
-  if (!this.skipReconnect) {
+  if (this._reconnection && !this.skipReconnect) {
     this.reconnect();
   }
 };

--- a/test/connection.js
+++ b/test/connection.js
@@ -44,6 +44,13 @@ describe('connection', function() {
     });
   });
 
+  it('should reconnect by default', function(done){
+    socket.io.engine.close();
+    socket.io.on('reconnect', function() {
+      done();
+    });
+  });
+
 if (!global.Blob && !global.ArrayBuffer) {
   it('should get base64 data as a last resort', function(done) {
     socket.on('takebin', function(a) {


### PR DESCRIPTION
The `reconnection` option is not true by default, even though the document says it's true.
We have to merge #635 to make the test pass.
