### PR TITLE
Forces browserify build to only insert global

### DIFF
--- a/support/browserify.js
+++ b/support/browserify.js
@@ -23,5 +23,5 @@ function build(fn){
   var opts = {};
   opts.entries = [path];
   opts.builtins = false;
-  browserify(opts).bundle({ standalone: 'io' }, fn);
+  browserify(opts).bundle({ standalone: 'io', insertGlobalVars: ['global'] }, fn);
 }


### PR DESCRIPTION
By whitelisting the vars we want inserted in the bundle options like this it looks like we can avoid slipping in Buffer and such for no reason.

Is `global` the only thing we need?
