### PR TITLE
0.9 handle transport open errors

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -218,6 +218,25 @@
 
       self.setHeartbeatTimeout();
 
+      function tryNext () {
+        if (!self.connected) {
+          self.connecting = false;
+
+          if (self.options['try multiple transports']) {
+            var remaining = self.transports;
+
+            while (remaining.length > 0 && remaining.splice(0,1)[0] !=
+                   self.transport.name) {}
+
+              if (remaining.length){
+                connect(remaining);
+              } else {
+                self.publish('connect_failed');
+              }
+          }
+        }
+      }
+
       function connect (transports){
         if (self.transport) self.transport.clearTimeouts();
 
@@ -228,27 +247,12 @@
         self.transport.ready(self, function () {
           self.connecting = true;
           self.publish('connecting', self.transport.name);
-          self.transport.open();
-
-          if (self.options['connect timeout']) {
-            self.connectTimeoutTimer = setTimeout(function () {
-              if (!self.connected) {
-                self.connecting = false;
-
-                if (self.options['try multiple transports']) {
-                  var remaining = self.transports;
-
-                  while (remaining.length > 0 && remaining.splice(0,1)[0] !=
-                         self.transport.name) {}
-
-                    if (remaining.length){
-                      connect(remaining);
-                    } else {
-                      self.publish('connect_failed');
-                    }
-                }
-              }
-            }, self.options['connect timeout']);
+          if(self.transport.open() !== null) {
+            if (self.options['connect timeout']) {
+              self.connectTimeoutTimer = setTimeout(function () , self.options['connect timeout']);
+            }
+          } else {
+            tryNext();
           }
         });
       }

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -63,7 +63,11 @@
       Socket = global.MozWebSocket || global.WebSocket;
     }
 
-    this.websocket = new Socket(this.prepareUrl() + query);
+    try {
+      this.websocket = new Socket(this.prepareUrl() + query);
+    } catch {
+      return null;
+    }
 
     this.websocket.onopen = function () {
       self.onOpen();


### PR DESCRIPTION
Added try/catch block in websocket open
If error on open immediately try next transport
Error occurs during web socket transport open on IE 10, 11 (Script5022: Syntax error) and do not proceed to next transport
