### PR TITLE
Allows user-level query string parameters to be in socket.request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,17 +42,17 @@ function lookup(uri, opts) {
   opts = opts || {};
 
   var parsed = url(uri);
-  var href = parsed.href;
+  var source = parsed.source;
   var id = parsed.id;
   var io;
 
   if (opts.forceNew || false === opts.multiplex) {
-    debug('ignoring socket cache for %s', href);
-    io = Manager(href, opts);
+    debug('ignoring socket cache for %s', source);
+    io = Manager(source, opts);
   } else {
     if (!cache[id]) {
-      debug('new io instance for %s', href);
-      cache[id] = Manager(href, opts);
+      debug('new io instance for %s', source);
+      cache[id] = Manager(source, opts);
     }
     io = cache[id];
   }


### PR DESCRIPTION
Uses the full url string rather than parsed.href;

Also relies on a PR in engine.io here: https://github.com/LearnBoost/engine.io/pull/245
