### PR TITLE
App dies if socket disconnects right in onConnect

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -286,7 +285,7 @@ Socket.prototype.onack = function(packet){
 Socket.prototype.onconnect = function(){
   this.connected = true;
   this.disconnected = false;
-  this.emit('connect');
+  this.emit('connect', function(err) {});
   this.emitBuffered();
 };
 


### PR DESCRIPTION
App dies if socket disconnects between in `onConnect` handler emitting the 'connect' message

This is the code throwing the exception from the `emit` method

``` js
WebSocket.prototype.send = function(data, options, cb) {
...
if (this.readyState != WebSocket.OPEN) {
    if (typeof cb == 'function') cb(new Error('not opened'));
    else throw new Error('not opened');
    return;
  }
...
```

For some strange reason some times, the client socket will receive the onConnect method but will disconnect just before emitting the `connect` message, so with the above exception, the app will die!
