### PR TITLE
socket should be disconnected when using namespace

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -153,11 +153,10 @@
         break;
 
       case 'disconnect':
-        if (this.name === '') {
-          this.socket.onDisconnect(packet.reason || 'booted');
-        } else {
+        if (this.name !== '') {
           this.$emit('disconnect', packet.reason);
         }
+        this.socket.onDisconnect(packet.reason || 'booted');
         break;
 
       case 'message':


### PR DESCRIPTION
socket.onDisconnect() was not called on client side when socket.disconnect() was called with using namespace on server side.

Therefore, transports were not closed and kept waiting for incoming packets.

This could cause a trouble when server is restarted or connection disrupted.
Browser consoles will show "Failed to load resources", for example, even after socket.disconnect() was called on server.

Related issue I found is: https://github.com/LearnBoost/socket.io/issues/795

This fix is very simple and it just call socket.onDisconnect() when using namespace.
