### PR TITLE
distinction between ACK and BINARY_ACK

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -207,6 +207,10 @@ Socket.prototype.onpacket = function(packet){
       this.onack(packet);
       break;
 
+    case parser.BINARY_ACK:
+      this.onack(packet);
+      break;
+
     case parser.DISCONNECT:
       this.ondisconnect();
       break;
@@ -255,8 +259,10 @@ Socket.prototype.ack = function(id){
     sent = true;
     var args = toArray(arguments);
     debug('sending ack %j', args);
+
+    var type = hasBin(args) ? parser.BINARY_ACK : parser.ACK;
     self.packet({
-      type: parser.ACK,
+      type: type,
       id: id,
       data: args
     });


### PR DESCRIPTION
test ack for binary data to set the packet type properly.
