### PR TITLE
Fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "emitter": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
     "bind": "http://github.com/component/bind/archive/0.0.1.tar.gz",
     "object-component": "0.0.3",
-    "socket.io-parser": "2.1.5",
+    "socket.io-parser": "2.2.0",
     "parseuri": "0.0.2",
     "to-array": "0.1.3",
     "debug": "0.7.4",
@@ -22,7 +22,7 @@
     "indexof": "0.0.1"
   },
   "devDependencies": {
-    "socket.io": "1.0.2",
+    "socket.io": "Automattic/socket.io#27dada6",
     "mocha": "1.16.2",
     "zuul": "1.6.3",
     "istanbul": "0.2.1",


### PR DESCRIPTION
Tests wouldn't pass before, because the socket.io server used for tests didn't have the UTF-8 fix, and would break for ack tests, having changes applied to the client. but not to the server.

We need a new version, and need to get https://github.com/Automattic/socket.io/pull/1565 in.
