### PR TITLE
add a buffer for emitted events to only send after connection

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -50,7 +50,8 @@ function Socket(io, nsp){
   this.ids = 0;
   this.acks = {};
   this.open();
-  this.buffer = [];
+  this.receiveBuffer = [];
+  this.sendBuffer = [];
   this.connected = false;
   this.disconnected = true;
 }
@@ -123,7 +124,11 @@ Socket.prototype.emit = function(ev){
     packet.id = this.ids++;
   }
 
-  this.packet(packet);
+  if (this.connected) {
+    this.packet(packet);
+  } else {
+    this.sendBuffer.push(packet);
+  }
 
   return this;
 };
@@ -240,7 +245,7 @@ Socket.prototype.onevent = function(packet){
   if (this.connected) {
     emit.apply(this, args);
   } else {
-    this.buffer.push(args);
+    this.receiveBuffer.push(args);
   }
 };
 
@@ -297,16 +302,22 @@ Socket.prototype.onconnect = function(){
 };
 
 /**
- * Emit buffered events.
+ * Emit buffered events (received and emitted).
  *
  * @api private
  */
 
 Socket.prototype.emitBuffered = function(){
-  for (var i = 0; i < this.buffer.length; i++) {
-    emit.apply(this, this.buffer[i]);
+  var i;
+  for (i = 0; i < this.receiveBuffer.length; i++) {
+    emit.apply(this, this.receiveBuffer[i]);
   }
-  this.buffer = [];
+  this.receiveBuffer = [];
+
+  for (i = 0; i < this.sendBuffer.length; i++) {
+    this.packet(this.sendBuffer[i]);
+  }
+  this.sendBuffer = [];
 };
 
 /**


### PR DESCRIPTION
this addresses https://github.com/Automattic/socket.io/issues/1573

added an "emit buffer" that holds on to packets that were emitted before the `connect` event is thrown. Upon connection this buffer is sent through. Now we have another buffer (I'm almost in favor of forcing listen to the `connect` event before emitting), but it doesn't seem too complex so I'll leave this for discussion.

will submit a relevant test to socket.io
