### PR TITLE
url: use strings for port, eqeq for port check

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -53,10 +53,10 @@ function url(uri, loc){
   // make sure we treat `localhost:80` and `localhost` equally
   if (!obj.port) {
     if (/^(http|ws)$/.test(obj.protocol)) {
-      obj.port = 80;
+      obj.port = '80';
     }
     else if (/^(http|ws)s$/.test(obj.protocol)) {
-      obj.port = 443;
+      obj.port = '443';
     }
   }
 
@@ -65,7 +65,7 @@ function url(uri, loc){
   // define unique id
   obj.id = obj.protocol + '://' + obj.host + ':' + obj.port;
   // define href
-  obj.href = obj.protocol + '://' + obj.host + (loc && loc.port === obj.port ? '' : (':' + obj.port));
+  obj.href = obj.protocol + '://' + obj.host + (loc && loc.port == obj.port ? '' : (':' + obj.port));
 
   return obj;
 }


### PR DESCRIPTION
This is a continuation of #655, specifically fixing the issue mentioned in [my last comment](https://github.com/Automattic/socket.io-client/pull/655#issuecomment-45954742).

Rewriting the `url` module will take a bit more time, so I figured I'd push this fix in the meantime.
