### PR TITLE
Handle io.connect(null, opts) correctly

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -29,7 +29,7 @@ module.exports = Manager;
 
 function Manager(uri, opts){
   if (!(this instanceof Manager)) return new Manager(uri, opts);
-  if ('object' == typeof uri) {
+  if (uri && ('object' == typeof uri)) {
     opts = uri;
     uri = undefined;
   }


### PR DESCRIPTION
In migrating to Socket.IO 1.0.x, we had to change `null` into `"/"` in:

```
io.connect(null, opts)
```

( See https://github.com/audreyt/ethercalc/commit/adbc86e529e2edac99bbcc7e3063e84b773169e0#diff-d87f0347aff1316677a2d709ec4b4777R49 )

This is because `typeof null` is `object`, so the options are discarded.

Fixed by checking for truth value of `uri` before checking its type.
