### PR TITLE
Delete bad test, set timeouts before disconnecting eioc

### DIFF
--- a/test/connection.js
+++ b/test/connection.js
@@ -8,7 +8,7 @@ describe('connection', function() {
   this.timeout(20000);
 
   it('should connect to localhost', function(done) {
-    var socket = io();
+    var socket = io({ forceNew: true });
     socket.emit('hi');
     socket.on('hi', function(data){
       done();
@@ -16,7 +16,7 @@ describe('connection', function() {
   });
 
   it('should work with acks', function(done){
-    var socket = io();
+    var socket = io({ forceNew: true });
     socket.emit('ack');
     socket.on('ack', function(fn){
       fn(5, { test: true });
@@ -25,7 +25,7 @@ describe('connection', function() {
   });
 
   it('should receive date with ack', function(done){
-    var socket = io();
+    var socket = io({ forceNew: true });
     socket.emit('getAckDate', { test: true }, function(data){
        expect(data).to.be.a('string');
        done();
@@ -33,7 +33,7 @@ describe('connection', function() {
   });
 
   it('should work with false', function(done){
-    var socket = io();
+    var socket = io({ forceNew: true });
     socket.emit('false');
     socket.on('false', function(f){
       expect(f).to.be(false);
@@ -50,7 +50,7 @@ describe('connection', function() {
       'utf8 — string'
     ];
 
-    var socket = io();
+    var socket = io({ forceNew: true });
     var i = 0;
     socket.on('takeUtf8', function(data) {
       expect(data).to.be(correct[i]);
@@ -76,19 +76,26 @@ describe('connection', function() {
   });
 
   it('should reconnect by default', function(done){
-    var socket = io();
-    socket.io.engine.close();
+    var socket = io({ forceNew: true });
     socket.io.on('reconnect', function() {
       done();
     });
+
+    setTimeout(function() {
+      socket.io.engine.close();
+    }, 500);
   });
 
   it('reconnect event should fire in socket', function(done){
-    var socket = io();
-    socket.io.engine.close();
+    var socket = io({ forceNew: true });
+
     socket.on('reconnect', function() {
       done();
     });
+
+    setTimeout(function() {
+      socket.io.engine.close();
+    }, 500);
   });
 
   it('should try to reconnect twice and fail when requested two attempts with immediate timeout and reconnect enabled', function(done) {
@@ -202,7 +209,7 @@ describe('connection', function() {
   }
 
   it('should emit date as string', function(done){
-      var socket = io();
+      var socket = io({ forceNew: true });
       socket.on('takeDate', function(data) {
         expect(data).to.be.a('string');
         done();
@@ -211,7 +218,7 @@ describe('connection', function() {
   });
 
   it('should emit date in object', function(done){
-      var socket = io();
+      var socket = io({ forceNew: true });
       socket.on('takeDateObj', function(data) {
         expect(data).to.be.an('object');
         expect(data.date).to.be.a('string');
@@ -222,7 +229,7 @@ describe('connection', function() {
 
   if (!global.Blob && !global.ArrayBuffer) {
     it('should get base64 data as a last resort', function(done) {
-      var socket = io();
+      var socket = io({ forceNew: true });
       socket.on('takebin', function(a) {
         expect(a.base64).to.be(true);
         var bytes = b64.toByteArray(a.data);
@@ -238,7 +245,7 @@ describe('connection', function() {
     var base64 = require('base64-arraybuffer');
 
     it('should get binary data (as an ArrayBuffer)', function(done){
-      var socket = io();
+      var socket = io({ forceNew: true });
       socket.emit('doge');
       socket.on('doge', function(buffer){
         expect(buffer instanceof ArrayBuffer).to.be(true);
@@ -247,7 +254,7 @@ describe('connection', function() {
     });
 
     it('should send binary data (as an ArrayBuffer)', function(done){
-      var socket = io();
+      var socket = io({ forceNew: true });
       socket.on('buffack', function(){
         done();
       });
@@ -256,7 +263,7 @@ describe('connection', function() {
     });
 
     it('should send binary data (as an ArrayBuffer) mixed with json', function(done) {
-      var socket = io();
+      var socket = io({ forceNew: true });
       socket.on('jsonbuff-ack', function() {
         done();
       });
@@ -265,7 +272,7 @@ describe('connection', function() {
     });
 
     it('should send events with ArrayBuffers in the correct order', function(done) {
-      var socket = io();
+      var socket = io({ forceNew: true });
       socket.on('abuff2-ack', function() {
         done();
       });
@@ -277,7 +284,7 @@ describe('connection', function() {
 
   if (global.Blob && null != textBlobBuilder('xxx')) {
     it('should send binary data (as a Blob)', function(done){
-      var socket = io();
+      var socket = io({ forceNew: true });
       socket.on('back', function(){
         done();
       });
@@ -286,7 +293,7 @@ describe('connection', function() {
     });
 
     it('should send binary data (as a Blob) mixed with json', function(done) {
-      var socket = io();
+      var socket = io({ forceNew: true });
       socket.on('jsonblob-ack', function() {
         done();
       });
@@ -295,7 +302,7 @@ describe('connection', function() {
     });
 
     it('should send events with Blobs in the correct order', function(done) {
-      var socket = io();
+      var socket = io({ forceNew: true });
       socket.on('blob3-ack', function() {
         done();
       });
@@ -303,20 +310,6 @@ describe('connection', function() {
       socket.emit('blob1', blob);
       socket.emit('blob2', 'second');
       socket.emit('blob3', blob);
-    });
-
-    it('should clear its packet buffer in case of disconnect', function(done) {
-      var socket = io();
-      var blob = textBlobBuilder('BLOBBLOB');
-      for (var i=0; i < 10; i++) { // fill the buffer
-        socket.emit('asdf', blob);
-      }
-      expect(socket.io.packetBuffer.length).to.not.be(0);
-      expect(socket.io.encoding).to.be(true);
-      socket.io.disconnect();
-      expect(socket.io.packetBuffer.length).to.be(0);
-      expect(socket.io.encoding).to.be(false);
-      done();
     });
   }
 });


### PR DESCRIPTION
Add a forceNew to all io calls to make sure tests are run in isolation of each other (no caching). Add timeout before disconnecting engine.io client so that the connection will be properly established before it's being closed. Remove a bad test that assumes the packet buffer operates totally synchronously and only passed because of the previous test's state being cached.
