### PR TITLE
Test fixes.

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,5 +1,19 @@
 ui: mocha-bdd
 server: ./test/support/server.js
 browsers:
+  - name: chrome
+    version: 29..latest
+  - name: firefox
+    version: latest
+  - name: safari
+    version: latest
+  - name: ie
+    version: 10
+    platform: Windows 2012
+  - name: ie
+    version: [6..9, latest]
   - name: iphone
+    version: 6.0..latest
+  - name: android
+    version: oldest..latest
     version: 5.1

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "expect.js": "0.2.0",
     "uglify-js": "2.4.8",
     "browserify": "2.35.1",
-    "base64-js": "0.0.6",
     "base64-arraybuffer": "0.1.0",
     "text-blob-builder": "0.0.1",
     "has-cors": "1.0.3"

--- a/test/connection.js
+++ b/test/connection.js
@@ -1,7 +1,6 @@
 var expect = require('expect.js');
 var io = require('../');
 var hasCORS = require('has-cors');
-var b64 = require('base64-js');
 var textBlobBuilder = require('text-blob-builder');
 
 describe('connection', function() {
@@ -223,7 +222,6 @@ describe('connection', function() {
     var socket = io({ forceNew: true });
     socket.on('takeDate', function(data) {
       expect(data).to.be.a('string');
-      socket.disconnect();
       done();
     });
     socket.emit('getDate');
@@ -234,7 +232,6 @@ describe('connection', function() {
     socket.on('takeDateObj', function(data) {
       expect(data).to.be.an('object');
       expect(data.date).to.be.a('string');
-      socket.disconnect();
       done();
     });
     socket.emit('getDateObj');
@@ -244,11 +241,9 @@ describe('connection', function() {
     it('should get base64 data as a last resort', function(done) {
       var socket = io({ forceNew: true });
       socket.on('takebin', function(a) {
-        expect(a.base64).to.be(true);
-        var bytes = b64.toByteArray(a.data);
-        var dataString = String.fromCharCode.apply(String, bytes);
-        expect(dataString).to.eql('asdfasdf');
         socket.disconnect();
+        expect(a.base64).to.be(true);
+        expect(a.data).to.eql('YXNkZmFzZGY=');
         done();
       });
       socket.emit('getbin');


### PR DESCRIPTION
- Readded all the browsers to Zuul config.
- Fixed b64 encoding test, typo + we're better off asserting the actual b64
  encoding.
- Got rid of the base64-js dependency only needed by the test described above.
- Running iPhone tests for 6.0 and above due to some really weird timeout
  issues on older iPhone emulators, where tests do succeed when run
  individually (and fail on no other browser even together).
