### PR TITLE
Don't readd subs when reconnecting

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -61,6 +61,7 @@ function Socket(io, nsp){
   this.sendBuffer = [];
   this.connected = false;
   this.disconnected = true;
+  this.subEvents();
 }
 
 /**
@@ -68,6 +69,21 @@ function Socket(io, nsp){
  */
 
 Emitter(Socket.prototype);
+
+/**
+ * Subscribe to open, close and packet events
+ *
+ * @api private
+ */
+
+Socket.prototype.subEvents = function() {
+  var io = this.io;
+  this.subs = [
+    on(io, 'open', bind(this, 'onopen')),
+    on(io, 'packet', bind(this, 'onpacket')),
+    on(io, 'close', bind(this, 'onclose'))
+  ];
+};
 
 /**
  * Called upon engine `open`.
@@ -79,18 +95,7 @@ Socket.prototype.open =
 Socket.prototype.connect = function(){
   if (this.connected) return this;
 
-  var io = this.io;
-  io.open(); // ensure open
-
-  // Don't readd listeners when manually reconnecting
-  if (!this.disconnected) {
-    this.subs = [
-      on(io, 'open', bind(this, 'onopen')),
-      on(io, 'packet', bind(this, 'onpacket')),
-      on(io, 'close', bind(this, 'onclose'))
-    ];
-  }
-
+  this.io.open(); // ensure open
   if ('open' == this.io.readyState) this.onopen();
   return this;
 };


### PR DESCRIPTION
Addresses https://github.com/Automattic/socket.io/issues/1586

Can't add a test case that requires a server close. Let's look into adding a test case to the socket.io repo.

`make test` => all green

The idea is that we only add subscription for open, packet and close events once. If the socket is disconnected and connect is called on it manually, we used to readd the events . Because Manager#connect doesn't call Socket#connect, we should be safe to only add the events in the constructor.
