### PR TITLE
Fix duplicate `reconnect_failed` event

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -151,7 +151,8 @@ Manager.prototype.timeout = function(v){
  */
 
 Manager.prototype.maybeReconnectOnOpen = function() {
-  if (!this.openReconnect && !this.reconnecting && this._reconnection) {
+  // Only try to reconnect if it's the first time we're connecting
+  if (!this.openReconnect && !this.reconnecting && this._reconnection && this.attempts === 0) {
     // keeps reconnection from firing twice for the same reconnection loop
     this.openReconnect = true;
     this.reconnect();


### PR DESCRIPTION
Don't fire an extra reconnect when we're not reconnecting after a failed initial connect.
