### PR TITLE
Remove disconnected field

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -60,7 +60,6 @@ function Socket(io, nsp){
   this.receiveBuffer = [];
   this.sendBuffer = [];
   this.connected = false;
-  this.disconnected = true;
   this.subEvents();
 }
 
@@ -187,7 +186,6 @@ Socket.prototype.onopen = function(){
 Socket.prototype.onclose = function(reason){
   debug('close (%s)', reason);
   this.connected = false;
-  this.disconnected = true;
   this.emit('disconnect', reason);
 };
 
@@ -302,7 +300,6 @@ Socket.prototype.onack = function(packet){
 
 Socket.prototype.onconnect = function(){
   this.connected = true;
-  this.disconnected = false;
   this.emit('connect');
   this.emitBuffered();
 };


### PR DESCRIPTION
Socket has both `connected` and `disconnected` fields which conflict with one another.
I think we can remove unused `disconnected` field.
