### PR TITLE
Fix autoConnect option

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -52,8 +52,8 @@ function Manager(uri, opts){
   this.packetBuffer = [];
   this.encoder = new parser.Encoder();
   this.decoder = new parser.Decoder();
-  if (opts.autoConnect !== false)
-    this.open();
+  this.autoConnect = opts.autoConnect !== false;
+  if (this.autoConnect) this.open();
 }
 
 /**

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -56,7 +56,7 @@ function Socket(io, nsp){
   this.json = this; // compat
   this.ids = 0;
   this.acks = {};
-  this.open();
+  if (this.io.autoConnect) this.open();
   this.receiveBuffer = [];
   this.sendBuffer = [];
   this.connected = false;

--- a/test/connection.js
+++ b/test/connection.js
@@ -16,9 +16,9 @@ describe('connection', function() {
   });
 
   it('should not connect when autoConnect option set to false', function() {
-    var socket = io({autoConnect: false});
+    var socket = io({ forceNew: true, autoConnect: false });
     expect(socket.io.engine).to.not.be.ok();
-  });  
+  });
 
   it('should work with acks', function(done){
     var socket = io({ forceNew: true });
@@ -81,6 +81,20 @@ describe('connection', function() {
       foo.on('connect', function(){
         foo.close();
         socket.close();
+        done();
+      });
+    });
+  });
+
+  it('should open a new namespace after connection gets closed', function(done){
+    var manager = io.Manager();
+    var socket = manager.socket('/');
+    socket.on('connect', function() {
+      socket.disconnect();
+    }).on('disconnect', function() {
+      var foo = manager.socket('/foo');
+      foo.on('connect', function() {
+        foo.disconnect();
         done();
       });
     });


### PR DESCRIPTION
We have to remove `Manager#open` method call for the `autoConnect` option.

I'm not sure whether should check `autoConnect` is enabled like the following:

```
if (false !== this.io.opts.autoConnect) {
  this.io.open(); // ensure open
}
```
