### PR TITLE
Enable to reconnect to a closed namespace

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -310,6 +310,9 @@ Manager.prototype.socket = function(nsp){
  */
 
 Manager.prototype.destroy = function(socket){
+  if (!this.nsps[socket.nsp]) return;
+
+  delete this.nsps[socket.nsp];
   --this.connected || this.close();
 };
 

--- a/test/connection.js
+++ b/test/connection.js
@@ -100,6 +100,21 @@ describe('connection', function() {
     });
   });
 
+  it('should create a new socket for a closed namespace', function(done) {
+    var manager = io.Manager();
+    var socket1 = manager.socket('/nsp');
+    socket1.on('connect', function() {
+      socket1.disconnect();
+    }).on('disconnect', function() {
+      var socket2 = manager.socket('/nsp');
+      expect(socket2).not.to.be(socket1);
+      socket2.on('connect', function() {
+        socket2.disconnect();
+        done();
+      });
+    });
+  });
+
   it('should reconnect by default', function(done){
     var socket = io({ forceNew: true });
     socket.io.on('reconnect', function() {


### PR DESCRIPTION
It looks like that reusing a closed socket is not allowed by design (is it just a bug?), but creating a new socket for a same namespace and manager should be at least, IMO.

Related issues:
- #730
- https://github.com/Automattic/socket.io/issues/1683
- https://github.com/Automattic/socket.io/issues/1667
