### PR TITLE
Removed unnecessary code from try block. Only decode packet is needed.

### DIFF
--- a/socket.io.js
+++ b/socket.io.js
@@ -2139,11 +2139,12 @@ Transport.prototype.onOpen = function () {
 Transport.prototype.onData = function(data){
   try {
     var packet = parser.decodePacket(data, this.socket.binaryType);
-    this.onPacket(packet);
   } catch(e){
     e.data = data;
     this.onError('parser decode error', e);
+    return;
   }
+  this.onPacket(packet);
 };
 
 /**


### PR DESCRIPTION
Take in mind this code:

``` javascript
socket.on('message', function (data) {
  // doing some stuff in my application

  // but then my application throw error
  throw new Error('Something went wrong here :(');
});
```

Two unwanted things happend here:
- I can't see that error thrown in browser console.
- Connection with server is terminated here.

That's because  in `Transport.prototype.onData` calling `onPacket` method is in same call stack as my application code listed above and additionaly is in try catch block. Decode packet error handler think that there was something wrong with decoding packet, and as result it terminates connection. But it's not true because error was raised in my application.
