### PR TITLE
Support no schema relative url

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -31,7 +31,9 @@ function url(uri, loc){
   // relative path support
   if ('string' == typeof uri) {
     if ('/' == uri.charAt(0)) {
-      if ('undefined' != typeof loc) {
+      if ('/' == uri.charAt(1)) {
+        uri = loc.protocol + uri;
+      } else {
         uri = loc.hostname + uri;
       }
     }

--- a/test/url.js
+++ b/test/url.js
@@ -1,5 +1,5 @@
 
-var old = global.location;
+var old = global.location = { protocol: 'http:', hostname: 'localhost'};
 var loc = {};
 var url = require('../lib/url');
 var expect = require('expect.js');
@@ -17,6 +17,14 @@ describe('url', function(){
   it('works with no protocol', function(){
     loc.protocol = 'http:';
     var parsed = url('localhost:3000', loc);
+    expect(parsed.host).to.be('localhost');
+    expect(parsed.port).to.be('3000');
+    expect(parsed.protocol).to.be('http');
+  });
+
+  it('works with no schema', function(){
+    loc.protocol = 'http:';
+    var parsed = url('//localhost:3000', loc);
     expect(parsed.host).to.be('localhost');
     expect(parsed.port).to.be('3000');
     expect(parsed.protocol).to.be('http');


### PR DESCRIPTION
Hello, there.

In 0.9.16, I used "relative url with no schema" as uri.
but it seems doesn't support current version. so I made a PR to support it.. :bow: 
