### PR TITLE
Prevent undefined callback error

### DIFF
--- a/socket.io.js
+++ b/socket.io.js
@@ -868,6 +868,7 @@ Socket.prototype.ack = function(id){
  */
 
 Socket.prototype.onack = function(packet){
+  if ('undefined' == typeof this.acks[packet.id]) return;
   debug('calling ack %s with %j', packet.id, packet.data);
   var fn = this.acks[packet.id];
   fn.apply(this, packet.data);


### PR DESCRIPTION
If the same callback() is called multiple times from the server, then the client ends up with "TypeError: fn is undefined", due to the fact that the acks object is updated (client callback is removed) after the first call.
