### PR TITLE
fix reconnection after reconnecting manually

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -179,6 +179,7 @@ Manager.prototype.connect = function(fn){
   var socket = this.engine;
   var self = this;
   this.readyState = 'opening';
+  this.skipReconnect = false;
 
   // emit `open`
   var openSub = on(socket, 'open', function() {

--- a/test/connection.js
+++ b/test/connection.js
@@ -128,6 +128,22 @@ describe('connection', function() {
     });
   });
 
+  it('should reconnect automatically after reconnecting manually', function(done){
+    var socket = io({ forceNew: true });
+    socket.once('connect', function() {
+      socket.disconnect();
+    }).once('disconnect', function() {
+      socket.on('reconnect', function() {
+        socket.disconnect();
+        done();
+      });
+      socket.connect();
+      setTimeout(function() {
+        socket.io.engine.close();
+      }, 500);
+    });
+  });
+
   it('reconnect event should fire in socket', function(done){
     var socket = io({ forceNew: true });
 


### PR DESCRIPTION
Fixed `skipReconnect` was true even after reconnecting manually. 

related: 
https://github.com/Automattic/socket.io-client/issues/733
https://github.com/Automattic/socket.io-client/issues/745
