### PR TITLE
Fixed "jsonp polling iframe removal error" on connection close when usin...

### DIFF
--- a/socket.io.js
+++ b/socket.io.js
@@ -2347,6 +2347,7 @@ JSONPPolling.prototype.doClose = function () {
   if (this.form) {
     this.form.parentNode.removeChild(this.form);
     this.form = null;
+    this.iframe = null;
   }
 
   Polling.prototype.doClose.call(this);


### PR DESCRIPTION
...g JSONP polling

When a disconnection occurs using JSONP, the browser will get out of stack space and crash. This has already been fixed in engine.io:

https://github.com/Automattic/engine.io-client/commit/d9f4317bae4077948a47ad67cb2ea651b0f7517d
