### PR TITLE
Fix socket.io issue #1862

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -165,13 +165,21 @@ Manager.prototype.maybeReconnectOnOpen = function() {
 /**
  * Sets the current transport `socket`.
  *
+ * @param {Socket} optional, the user Socket that needs the connection
  * @param {Function} optional, callback
  * @return {Manager} self
  * @api public
  */
 
 Manager.prototype.open =
-Manager.prototype.connect = function(fn){
+Manager.prototype.connect = function(usersocket, fn){
+  if (!fn && 'function' == typeof usersocket) {
+    fn = usersocket;
+    usersocket = null;
+  } else if (usersocket && !~indexOf(this.connecting, usersocket)) {
+    this.connecting.push(usersocket);
+  }
+
   debug('readyState %s', this.readyState);
   if (~this.readyState.indexOf('open')) return this;
 
@@ -297,9 +305,6 @@ Manager.prototype.socket = function(nsp){
   if (!socket) {
     socket = new Socket(this, nsp);
     this.nsps[nsp] = socket;
-    if (!~indexOf(this.connecting, socket)) {
-      this.connecting.push(socket);
-    }
   }
   return socket;
 };

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -47,7 +47,7 @@ function Manager(uri, opts){
   this.timeout(null == opts.timeout ? 20000 : opts.timeout);
   this.readyState = 'closed';
   this.uri = uri;
-  this.connected = [];
+  this.connecting = [];
   this.attempts = 0;
   this.encoding = false;
   this.packetBuffer = [];
@@ -297,12 +297,9 @@ Manager.prototype.socket = function(nsp){
   if (!socket) {
     socket = new Socket(this, nsp);
     this.nsps[nsp] = socket;
-    var self = this;
-    socket.on('connect', function(){
-      if (!~indexOf(self.connected, socket)) {
-        self.connected.push(socket);
-      }
-    });
+    if (!~indexOf(this.connecting, socket)) {
+      this.connecting.push(socket);
+    }
   }
   return socket;
 };
@@ -314,9 +311,9 @@ Manager.prototype.socket = function(nsp){
  */
 
 Manager.prototype.destroy = function(socket){
-  var index = indexOf(this.connected, socket);
-  if (~index) this.connected.splice(index, 1);
-  if (this.connected.length) return;
+  var index = indexOf(this.connecting, socket);
+  if (~index) this.connecting.splice(index, 1);
+  if (this.connecting.length) return;
 
   this.close();
 };

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -96,7 +96,7 @@ Socket.prototype.connect = function(){
   if (this.connected) return this;
 
   this.subEvents();
-  this.io.open(); // ensure open
+  this.io.open(this); // ensure open
   if ('open' == this.io.readyState) this.onopen();
   return this;
 };

--- a/socket.io.js
+++ b/socket.io.js
@@ -141,7 +141,7 @@ function Manager(uri, opts){
   this.timeout(null == opts.timeout ? 20000 : opts.timeout);
   this.readyState = 'closed';
   this.uri = uri;
-  this.connected = [];
+  this.connecting = [];
   this.attempts = 0;
   this.encoding = false;
   this.packetBuffer = [];
@@ -391,12 +391,9 @@ Manager.prototype.socket = function(nsp){
   if (!socket) {
     socket = new Socket(this, nsp);
     this.nsps[nsp] = socket;
-    var self = this;
-    socket.on('connect', function(){
-      if (!~indexOf(self.connected, socket)) {
-        self.connected.push(socket);
-      }
-    });
+    if (!~indexOf(self.connecting, socket)) {
+      this.connecting.push(socket);
+    }
   }
   return socket;
 };
@@ -408,9 +405,9 @@ Manager.prototype.socket = function(nsp){
  */
 
 Manager.prototype.destroy = function(socket){
-  var index = indexOf(this.connected, socket);
-  if (~index) this.connected.splice(index, 1);
-  if (this.connected.length) return;
+  var index = indexOf(this.connecting, socket);
+  if (~index) this.connecting.splice(index, 1);
+  if (this.connecting.length) return;
 
   this.close();
 };

--- a/socket.io.js
+++ b/socket.io.js
@@ -141,7 +141,7 @@ function Manager(uri, opts){
   this.timeout(null == opts.timeout ? 20000 : opts.timeout);
   this.readyState = 'closed';
   this.uri = uri;
-  this.connecting = [];
+  this.connected = [];
   this.attempts = 0;
   this.encoding = false;
   this.packetBuffer = [];
@@ -391,9 +391,12 @@ Manager.prototype.socket = function(nsp){
   if (!socket) {
     socket = new Socket(this, nsp);
     this.nsps[nsp] = socket;
-    if (!~indexOf(self.connecting, socket)) {
-      this.connecting.push(socket);
-    }
+    var self = this;
+    socket.on('connect', function(){
+      if (!~indexOf(self.connected, socket)) {
+        self.connected.push(socket);
+      }
+    });
   }
   return socket;
 };
@@ -405,9 +408,9 @@ Manager.prototype.socket = function(nsp){
  */
 
 Manager.prototype.destroy = function(socket){
-  var index = indexOf(this.connecting, socket);
-  if (~index) this.connecting.splice(index, 1);
-  if (this.connecting.length) return;
+  var index = indexOf(this.connected, socket);
+  if (~index) this.connected.splice(index, 1);
+  if (this.connected.length) return;
 
   this.close();
 };


### PR DESCRIPTION
See https://github.com/Automattic/socket.io/issues/1862 for the repro
case.  Basically, if connecting to one namespace at the same time
as disconnecting from another, the connection gets lost.  We should
keep the connection alive as long as anybody is "connecting".

This code shrinks the code slightly and fixes this bug.