### PR TITLE
accept relative paths and Location objects for io.connect(url)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,11 +35,13 @@ var cache = exports.managers = {};
 
 function lookup(uri, opts) {
   if (typeof uri == 'object') {
-    opts = uri;
-    uri = undefined;
+    if (uri && !('href' in uri)) {
+      // A not-location-like object argument is an option.
+      opts = uri;
+      uri = undefined;
+    }
   }
-
-  opts = opts || {};
+  opts = copy(opts);
 
   var parsed = url(uri);
   var source = parsed.source;
@@ -58,6 +60,18 @@ function lookup(uri, opts) {
   }
 
   return io.socket(parsed.path);
+}
+
+/**
+ * A simplistic utility for copying options objects, to
+ * avoid mutating data sent by the caller.
+ *
+ *  @param {obj} the options object to copy
+ */
+function copyopt(obj) {
+  var result = {};
+  if (obj) for (var prop in obj) result[prop] = obj[prop];
+  return result;
 }
 
 /**

--- a/lib/url.js
+++ b/lib/url.js
@@ -3,7 +3,6 @@
  * Module dependencies.
  */
 
-var parseuri = require('parseuri');
 var debug = require('debug')('socket.io-client:url');
 
 /**
@@ -12,8 +11,27 @@ var debug = require('debug')('socket.io-client:url');
 
 module.exports = url;
 
+
 /**
- * URL parser.
+ * based on parseuri 1.2.2 'strict' mode
+ * (c) Steven Levithan <stevenlevithan.com>
+ * MIT License
+ * see: http://blog.stevenlevithan.com/archives/parseuri
+ * Included inline to eliminate unused code and reduce library size.
+ */
+function parseuri(str) {
+  var
+    strict = /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,
+    key = ["source","protocol","authority","userInfo","user","password","host","port","relative","path","directory","file","query","anchor"],
+    m   = strict.exec(str),
+    uri = {},
+    i   = 14;
+  while (i--) uri[key[i]] = m[i] || "";
+  return uri;
+};
+
+/**
+ * socket.io URL parser.  Resolves URLs relative to location.
  *
  * @param {String} url
  * @param {Object} An object meant to mimic window.location.
@@ -25,49 +43,44 @@ function url(uri, loc){
   var obj = uri;
 
   // default to window.location
-  var loc = loc || global.location;
+  var loc = loc || global.location || {};
   if (null == uri) uri = loc.protocol + '//' + loc.hostname;
 
   // relative path support
   if ('string' == typeof uri) {
-    if ('/' == uri.charAt(0)) {
-      if ('/' == uri.charAt(1)) {
-        uri = loc.protocol + uri;
-      } else {
-        uri = loc.hostname + uri;
-      }
+    if ('.' == uri.charAt(0)) {
+      var dirs = [];
+      var qpart = uri.split(/(?=\?)/); // Protect any query parts.
+      uri = loc.pathname || '/';
+      uri = uri.substr(0, uri.lastIndexOf('/') + 1) + qpart.shift();
+      uri.replace(/\/\.\.?$/, '$&/').replace(/\/?[^\/]*/g, function (p) {
+        if (p == '/..') {
+          dirs.pop();
+        } else if (p != '/.') {
+          dirs.push(p);
+        }
+      });
+      uri = (dirs.join('') || '/') + qpart.join('');
     }
-
-    if (!/^(https?|wss?):\/\//.test(uri)) {
+    if (!/^\/|^\w+:\/\//.test(uri)) {
+      // Historically 'foo.com' is a hostname for us, not a relative path.
       debug('protocol-less url %s', uri);
-      if ('undefined' != typeof loc) {
-        uri = loc.protocol + '//' + uri;
-      } else {
-        uri = 'https://' + uri;
-      }
+      uri = '//' + uri;
     }
-
     // parse
     debug('parse %s', uri);
     obj = parseuri(uri);
   }
 
-  // make sure we treat `localhost:80` and `localhost` equally
-  if (!obj.port) {
-    if (/^(http|ws)$/.test(obj.protocol)) {
-      obj.port = '80';
-    }
-    else if (/^(http|ws)s$/.test(obj.protocol)) {
-      obj.port = '443';
-    }
-  }
-
-  obj.path = obj.path || '/';
-
-  // define unique id
-  obj.id = obj.protocol + '://' + obj.host + ':' + obj.port;
-  // define href
-  obj.href = obj.protocol + '://' + obj.host + (loc && loc.port == obj.port ? '' : (':' + obj.port));
-
-  return obj;
+  var host = obj.hostname || obj.host || loc.hostname;
+  var protocol = (obj.protocol || loc.protocol || 'https').replace(/:$/, '');
+  var port = obj.port || (/^(?:http|ws)s$/.test(protocol) ? 443 : 80);
+  return {
+    protocol: protocol,
+    host: host,
+    port: port,
+    path: obj.path || obj.pathname || '/',
+    id: obj.protocol + '://' + host + ':' + port,
+    href: obj.protocol + '://' + host + (loc.port == port ? '' : (':' + port))
+  };
 }

--- a/lib/url.js
+++ b/lib/url.js
@@ -80,7 +80,6 @@ function url(uri, loc){
     host: host,
     port: port,
     path: obj.path || obj.pathname || '/',
-    id: obj.protocol + '://' + host + ':' + port,
-    href: obj.protocol + '://' + host + (loc.port == port ? '' : (':' + port))
+    id: obj.protocol + '://' + host + ':' + port
   };
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "has-binary": "0.1.5",
     "indexof": "0.0.1",
     "object-component": "0.0.3",
-    "parseuri": "0.0.2",
     "to-array": "0.1.3"
   },
   "devDependencies": {

--- a/test/url.js
+++ b/test/url.js
@@ -6,12 +6,41 @@ var expect = require('expect.js');
 
 describe('url', function(){
 
-  it('works with relative paths', function(){
+  it('works with root relative paths', function(){
     loc.hostname = 'woot.com';
     loc.protocol = 'https:';
     var parsed = url('/test', loc);
     expect(parsed.host).to.be('woot.com');
     expect(parsed.protocol).to.be('https');
+    expect(parsed.path).to.be('/test');
+  });
+
+  it('works with dot path', function(){
+    loc.hostname = 'deep.com';
+    loc.protocol = 'http:';
+    loc.pathname = '/top/sample/page.html';
+    var parsed = url('.', loc);
+    expect(parsed.host).to.be('deep.com');
+    expect(parsed.protocol).to.be('http');
+    expect(parsed.path).to.be('/top/sample/');
+    var parsed2 = url('./endpoint', loc);
+    expect(parsed2.host).to.be('deep.com');
+    expect(parsed2.protocol).to.be('http');
+    expect(parsed2.path).to.be('/top/sample/endpoint');
+  });
+
+  it('works with dot dot path', function(){
+    loc.hostname = 'deep.com';
+    loc.protocol = 'http:';
+    loc.pathname = '/top/sample/page.html';
+    var parsed = url('..', loc);
+    expect(parsed.host).to.be('deep.com');
+    expect(parsed.protocol).to.be('http');
+    expect(parsed.path).to.be('/top/');
+    var parsed2 = url('../shared/./endpoint', loc);
+    expect(parsed2.host).to.be('deep.com');
+    expect(parsed2.protocol).to.be('http');
+    expect(parsed2.path).to.be('/top/shared/endpoint');
   });
 
   it('works with no protocol', function(){
@@ -46,6 +75,20 @@ describe('url', function(){
     expect(url('/woot').path).to.be('/woot');
     expect(url('http://google.com').path).to.be('/');
     expect(url('http://google.com/').path).to.be('/');
+  });
+
+  it('works with Location-like object', function(){
+    loc.hostname = 'deep.com';
+    loc.protocol = 'https:';
+    loc.pathname = '/top/sample/page.html';
+    var parsed = url({
+      hostname: 'other.com',
+      port:8888,
+      pathname: '/top/check'}, loc);
+    expect(parsed.host).to.be('other.com');
+    expect(parsed.protocol).to.be('https');
+    expect(parsed.port).to.be(8888);
+    expect(parsed.path).to.be('/top/check');
   });
 
 });


### PR DESCRIPTION
Relative path support is added, to allow JS to be written that can be moved to different locations and different namespaces without changing the code.  Allows socket.io namespaces to be arranged the same way URLs are arranged.

Also, this change avoids changing the passed option objects in-place, so window.location can be passed as a URL.

Examples.  Suppose the client is being used where location.href is 'http://myhost.com/mydir/myfile

Then:
io.connect('.') is equivalent to io.connect('http://myhost.com/mydir/')
io.connect('..') is equivalent to io.connect('http://myhost.com/')
io.connect('./endpoint') is equivalent to io.connect('http://myhost.com/mydir/endpoint')
io.connect(location) is equivalent to io.connect('http://myhost.com/mydir/myfile')

Notice that io.connect('www.myhost.com') is unchanged and is not treated as relative - it's still treated as a hostname.  Relative paths need to start with a dot.