### PR TITLE
Support volatile messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ A property on the `socket` instance that is equal to the underlying engine.io so
 
 The property is present once the socket has connected, is removed when the socket disconnects and is updated if the socket reconnects.
 
+#### Socket#volatile():Socket
+
+  Sets a modifier for a subsequent event emission that the event message will
+  be dropped when this client is not ready to send messages.
+
+  ```js
+  socket.volatile().emit('an event', { some: 'data' });
+  ```
+
 #### Socket#compress(v:Boolean):Socket
 
   Sets a modifier for a subsequent event emission that the event data will

--- a/README.md
+++ b/README.md
@@ -153,13 +153,13 @@ A property on the `socket` instance that is equal to the underlying engine.io so
 
 The property is present once the socket has connected, is removed when the socket disconnects and is updated if the socket reconnects.
 
-#### Socket#volatile():Socket
+#### Socket#volatile:Socket
 
   Sets a modifier for a subsequent event emission that the event message will
   be dropped when this client is not ready to send messages.
 
   ```js
-  socket.volatile().emit('an event', { some: 'data' });
+  socket.volatile.emit('an event', { some: 'data' });
   ```
 
 #### Socket#compress(v:Boolean):Socket

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -359,18 +359,21 @@ Manager.prototype.destroy = function(socket){
 Manager.prototype.packet = function(packet){
   debug('writing packet %j', packet);
   var self = this;
+  var opts = packet.options || {};
 
   if (!self.encoding) {
     // encode, then write to engine with result
     self.encoding = true;
     this.encoder.encode(packet, function(encodedPackets) {
-      for (var i = 0; i < encodedPackets.length; i++) {
-        self.engine.write(encodedPackets[i], packet.options);
+      if (!opts.volatile || self.engine.transport.writable) {
+        for (var i = 0; i < encodedPackets.length; i++) {
+          self.engine.write(encodedPackets[i], opts);
+        }
       }
       self.encoding = false;
       self.processPacketQueue();
     });
-  } else { // add packet to the queue
+  } else if (!opts.volatile) { // add packet to the queue
     self.packetBuffer.push(packet);
   }
 };

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -136,6 +136,7 @@ Socket.prototype.emit = function(ev){
   var packet = { type: parserType, data: args };
 
   packet.options = {}
+  packet.options.volatile = this.flags && this.flags.volatile;
   packet.options.compress = !this.flags || false !== this.flags.compress;
 
   // event ack callback
@@ -401,5 +402,18 @@ Socket.prototype.disconnect = function(){
 Socket.prototype.compress = function(compress){
   this.flags = this.flags || {};
   this.flags.compress = compress;
+  return this;
+};
+
+/**
+ * Sets the volatile flag.
+ *
+ * @return {Socket} self
+ * @api public
+ */
+
+Socket.prototype.volatile = function(){
+  this.flags = this.flags || {};
+  this.flags.volatile = true;
   return this;
 };

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -40,10 +40,30 @@ var events = {
 };
 
 /**
+ * Flags.
+ *
+ * @api private
+ */
+
+var flags = ['volatile'];
+
+/**
  * Shortcut to `Emitter#emit`.
  */
 
 var emit = Emitter.prototype.emit;
+
+/**
+ * Creates a new object with the specified prototype object.
+ *
+ * @api private
+ */
+
+var create = Object.create || function(proto) {
+  var F = function(){};
+  F.prototype = proto;
+  return new F();
+};
 
 /**
  * `Socket` constructor.
@@ -62,6 +82,9 @@ function Socket(io, nsp){
   this.sendBuffer = [];
   this.connected = false;
   this.disconnected = true;
+  this.flags = {};
+  this.self = this;
+  this.initFlags();
 }
 
 /**
@@ -138,14 +161,14 @@ Socket.prototype.emit = function(ev){
   var packet = { type: parserType, data: args };
 
   packet.options = {}
-  packet.options.volatile = this.flags && this.flags.volatile;
-  packet.options.compress = !this.flags || false !== this.flags.compress;
+  packet.options.volatile = !!this.flags.volatile;
+  packet.options.compress = false !== this.flags.compress;
 
   // event ack callback
   if ('function' == typeof args[args.length - 1]) {
     debug('emitting packet with ack id %d', this.ids);
     this.acks[this.ids] = args.pop();
-    packet.id = this.ids++;
+    packet.id = this.self.ids++;
   }
 
   if (this.connected) {
@@ -154,9 +177,7 @@ Socket.prototype.emit = function(ev){
     this.sendBuffer.push(packet);
   }
 
-  delete this.flags;
-
-  return this;
+  return this.self;
 };
 
 /**
@@ -406,20 +427,45 @@ Socket.prototype.disconnect = function(){
  */
 
 Socket.prototype.compress = function(compress){
-  this.flags = this.flags || {};
-  this.flags.compress = compress;
-  return this;
+  return this.createFlag('compress', compress);
 };
 
 /**
- * Sets the volatile flag.
+ * Initialize all flags.
  *
- * @return {Socket} self
- * @api public
+ * @api private
  */
 
-Socket.prototype.volatile = function(){
-  this.flags = this.flags || {};
-  this.flags.volatile = true;
-  return this;
-};
+Socket.prototype.initFlags = function(){
+  for (var i = 0, len = flags.length; i < len; i ++) {
+    var flag = flags[i];
+    if (this.flags[flag]) continue;
+    this[flag] = this.createFlag(flag);
+  }
+}
+
+/**
+ * Clones the socket with the flag.
+ *
+ * @param {String} flag name
+ * @param {Boolean} value, default to true
+ * @api private
+ */
+
+Socket.prototype.createFlag = function(flag, v){
+  if ('undefined' === typeof v) {
+    v = true;
+  }
+  var socket = create(this.self);
+  var flags = {};
+  for (var k in this.flags) {
+    if (this.flags.hasOwnProperty(k)) {
+      flags[k] = this.flags[k];
+    }
+  }
+  flags[flag] = v;
+  socket.flags = flags;
+  socket.initFlags();
+  return socket;
+}
+

--- a/test/socket.js
+++ b/test/socket.js
@@ -105,7 +105,7 @@ describe('socket', function(){
         counter++;
       });
       socket.emit('hi');
-      socket.volatile().emit('hi');
+      socket.volatile.emit('hi');
 
       setTimeout(function() {
         expect(counter).to.be(1);
@@ -121,7 +121,7 @@ describe('socket', function(){
       socket.on('hi', function(){
         counter++;
       });
-      socket.volatile().emit('hi');
+      socket.volatile.emit('hi');
 
       setTimeout(function() {
         expect(counter).to.be(1);
@@ -137,7 +137,8 @@ describe('socket', function(){
       socket.on('hi', function(){
         counter++;
       });
-      socket.volatile().emit('hi');
+      socket.volatile.emit('hi');
+      socket.volatile.emit('hi');
 
       setTimeout(function() {
         expect(counter).to.be(1);
@@ -154,7 +155,7 @@ describe('socket', function(){
         counter++;
       });
       socket.emit('hi');
-      socket.volatile().emit('hi');
+      socket.volatile.emit('hi');
       socket.emit('hi');
 
       setTimeout(function() {
@@ -173,7 +174,7 @@ describe('socket', function(){
           counter++;
         });
         socket.emit('hi');
-        socket.volatile().emit('hi');
+        socket.volatile.emit('hi');
 
         setTimeout(function() {
           expect(counter).to.be(1);
@@ -189,7 +190,7 @@ describe('socket', function(){
         socket.on('hi', function(){
           counter++;
         });
-        socket.volatile().emit('hi');
+        socket.volatile.emit('hi');
 
         setTimeout(function() {
           expect(counter).to.be(1);
@@ -205,7 +206,8 @@ describe('socket', function(){
         socket.on('hi', function(){
           counter++;
         });
-        socket.volatile().emit('hi');
+        socket.volatile.emit('hi');
+        socket.volatile.emit('hi');
 
         setTimeout(function() {
           expect(counter).to.be(1);
@@ -222,7 +224,7 @@ describe('socket', function(){
           counter++;
         });
         socket.emit('hi');
-        socket.volatile().emit('hi');
+        socket.volatile.emit('hi');
         socket.emit('hi');
 
         setTimeout(function() {
@@ -232,4 +234,16 @@ describe('socket', function(){
       });
     });
   }
+
+  it('should set volatile and compress flags', function(done){
+    var socket = io({ forceNew: true });
+    socket.on('connect', function(){
+      socket.io.engine.once('packetCreate', function(packet){
+        expect(packet.options.volatile).to.be(true);
+        expect(packet.options.compress).to.be(false);
+        done();
+      });
+      socket.volatile.compress(false).emit('hi');
+    });
+  });
 });

--- a/test/socket.js
+++ b/test/socket.js
@@ -66,4 +66,140 @@ describe('socket', function(){
       socket.compress(false).emit('hi');
     });
   });
+
+  it('should not emit volatile event after regular event (polling)', function(done) {
+    var socket = io({ forceNew: true, transports: ['polling'] });
+    socket.on('connect', function(){
+      var counter = 0;
+      socket.on('hi', function(){
+        counter++;
+      });
+      socket.emit('hi');
+      socket.volatile().emit('hi');
+
+      setTimeout(function() {
+        expect(counter).to.be(1);
+        done();
+      }, 1000);
+    });
+  });
+
+  it('should emit volatile event (polling)', function(done) {
+    var socket = io({ forceNew: true, transports: ['polling'] });
+    socket.on('connect', function(){
+      var counter = 0;
+      socket.on('hi', function(){
+        counter++;
+      });
+      socket.volatile().emit('hi');
+
+      setTimeout(function() {
+        expect(counter).to.be(1);
+        done();
+      }, 1000);
+    });
+  });
+
+  it('should emit only one consecutive volatile event (polling)', function(done) {
+    var socket = io({ forceNew: true, transports: ['polling'] });
+    socket.on('connect', function(){
+      var counter = 0;
+      socket.on('hi', function(){
+        counter++;
+      });
+      socket.volatile().emit('hi');
+
+      setTimeout(function() {
+        expect(counter).to.be(1);
+        done();
+      }, 1000);
+    });
+  });
+
+  it('should emit regular events after trying a failed volatile event (polling)', function(done) {
+    var socket = io({ forceNew: true, transports: ['polling'] });
+    socket.on('connect', function(){
+      var counter = 0;
+      socket.on('hi', function(){
+        counter++;
+      });
+      socket.emit('hi');
+      socket.volatile().emit('hi');
+      socket.emit('hi');
+
+      setTimeout(function() {
+        expect(counter).to.be(2);
+        done();
+      }, 1000);
+    });
+  });
+
+  if (global.WebSocket) {
+    it('should not emit volatile event after regular event (ws)', function(done) {
+      var socket = io({ forceNew: true, transports: ['websocket'] });
+      socket.on('connect', function(){
+        var counter = 0;
+        socket.on('hi', function(){
+          counter++;
+        });
+        socket.emit('hi');
+        socket.volatile().emit('hi');
+
+        setTimeout(function() {
+          expect(counter).to.be(1);
+          done();
+        }, 1000);
+      });
+    });
+
+    it('should emit volatile event (ws)', function(done) {
+      var socket = io({ forceNew: true, transports: ['websocket'] });
+      socket.on('connect', function(){
+        var counter = 0;
+        socket.on('hi', function(){
+          counter++;
+        });
+        socket.volatile().emit('hi');
+
+        setTimeout(function() {
+          expect(counter).to.be(1);
+          done();
+        }, 1000);
+      });
+    });
+
+    it('should emit only one consecutive volatile event (ws)', function(done) {
+      var socket = io({ forceNew: true, transports: ['websocket'] });
+      socket.on('connect', function(){
+        var counter = 0;
+        socket.on('hi', function(){
+          counter++;
+        });
+        socket.volatile().emit('hi');
+
+        setTimeout(function() {
+          expect(counter).to.be(1);
+          done();
+        }, 1000);
+      });
+    });
+
+    it('should emit regular events after trying a failed volatile event (ws)', function(done) {
+      var socket = io({ forceNew: true, transports: ['websocket'] });
+      socket.on('connect', function(){
+        var counter = 0;
+        socket.on('hi', function(){
+          counter++;
+        });
+        socket.emit('hi');
+        socket.volatile().emit('hi');
+        socket.emit('hi');
+
+        setTimeout(function() {
+          expect(counter).to.be(2);
+          done();
+        }, 1000);
+      });
+    });
+  }
 });


### PR DESCRIPTION
This PR adds `socket#volatile()`.

We have to merge https://github.com/Automattic/engine.io-client/pull/375 to pass all tests.

Related: https://github.com/Automattic/socket.io-client/issues/283, https://github.com/Automattic/socket.io-client/pull/710, https://github.com/Automattic/socket.io/issues/2003
