### PR TITLE
added a main for JSPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "client"
   ],
   "main": "./lib/index",
+  "jspm": {
+    "main": "socket.io.js"
+  },
   "dependencies": {
     "debug": "2.1.3",
     "engine.io-client": "automattic/engine.io-client#fb7c198",


### PR DESCRIPTION
jspm people like me would love it, if we could have our main defined such as this.
that wouls allow us to do:
```
jspm install socket.io-client
```
and it would work without us overriding anything in jspm registry. Now JSPM installs socket.io as NPM package, which means all of the work porting the socket.io to browser done by hand by socket.io developers goes PUFF! More on this: https://github.com/jspm/jspm-cli/issues/780
Thank you for your consideration.