### PR TITLE
added closed event and listener to remove the manager from the cache

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,6 +58,9 @@ function lookup(uri, opts) {
     if (!cache[id]) {
       debug('new io instance for %s', source);
       cache[id] = Manager(source, opts);
+      cache[id].on('closed', function(){
+        delete cache[id];
+      });
     }
     io = cache[id];
   }

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -450,6 +450,7 @@ Manager.prototype.disconnect = function(){
   this.backoff.reset();
   this.readyState = 'closed';
   if (this.engine) this.engine.close();
+  this.emit('closed');
 };
 
 /**


### PR DESCRIPTION
fixes #866 

When all sockets have been disconnected the Manager for that/those sockets is never removed from the cache.

If the socket(s) are manually re-connected the logic that determines if this is a new connection incorrectly identifies the old Manager and Namespace objects in the cache (assuming that they use the same name spaces). This forces each new connection to be flagged as newConnection (aka forceNew = true) and prevents multiplexing when manually re-establishing pre-existing connections.

This is problematic in the following situation:

```
Login > establish initial socket
Load Widgets > each multiplex their socket through the same Manager
Logout > all sockets torn down
Login (without navigating away) > Every socket (including all widgets) establish an independent connection (no multiplexing).
```

To clean up the Managers I emitted a 'closed' event within the Manager.close() method, which can be called manually or automatically when all child sockets have closed. When this event fires the Manager is removed from the cache, resolving the issue.

Unsure if this breaks any by-design reason that the Manager was retained after it had been closed.
