### PR TITLE
Emit connection_failed event when connection is refused. Resolves #485.

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -161,6 +161,7 @@
           } else if (xhr.status == 403) {
             self.onError(xhr.responseText);
           } else {
+            self.publish('connect_failed', xhr.responseText, xhr, self.reconnecting );
             self.connecting = false;            
             !self.reconnecting && self.onError(xhr.responseText);
           }


### PR DESCRIPTION
This is a simple PR that implements the fix that @shimondoodkin suggested in PR
https://github.com/socketio/socket.io-client/issues/485#issuecomment-10365852.

This fix is verified working locally, but even though the issue was closed I did not see this code in the `0.9` branch.