### PR TITLE
Avoid reserved words 'long' and 'short'.

### DIFF
--- a/socket.io.js
+++ b/socket.io.js
@@ -3985,9 +3985,7 @@ var y = d * 365.25;
 module.exports = function(val, options){
   options = options || {};
   if ('string' == typeof val) return parse(val);
-  return options.long
-    ? long(val)
-    : short(val);
+  return options['long'] ? longFormat(val) : shortFormat(val);
 };
 
 /**
@@ -4037,7 +4035,7 @@ function parse(str) {
  * @api private
  */
 
-function short(ms) {
+function shortFormat(ms) {
   if (ms >= d) return Math.round(ms / d) + 'd';
   if (ms >= h) return Math.round(ms / h) + 'h';
   if (ms >= m) return Math.round(ms / m) + 'm';
@@ -4053,7 +4051,7 @@ function short(ms) {
  * @api private
  */
 
-function long(ms) {
+function longFormat(ms) {
   return plural(ms, d, 'day')
     || plural(ms, h, 'hour')
     || plural(ms, m, 'minute')


### PR DESCRIPTION
In javascript, 'long' and 'short' are reserved words.
They were used for formatting times in a couple places.
Some syntax checkers consider their use as errors, so it's easiest just to rename the functions.

Functionally, there should be no change.

Closes #807 