### PR TITLE
Working travis build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # socket.io-client
 
-[![Build Status](https://secure.travis-ci.org/Automattic/socket.io-client.svg)](http://travis-ci.org/Automattic/socket.io-client)
+[![Build Status](https://secure.travis-ci.org/socketio/socket.io-client.svg)](http://travis-ci.org/socketio/socket.io-client)
 ![NPM version](https://badge.fury.io/js/socket.io-client.svg)
 ![Downloads](http://img.shields.io/npm/dm/socket.io-client.svg?style=flat)
 [![](http://slack.socket.io/badge.svg)](http://slack.socket.io)


### PR DESCRIPTION
Remove broken build status caused by the name change of the github organization.