### PR TITLE
Enable to run all tests on nodejs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ test:
 test-node:
 	@./node_modules/.bin/mocha \
 		--reporter $(REPORTER) \
+		--require test/support/server.js \
 		test/index.js
 
 test-zuul:

--- a/test/connection.js
+++ b/test/connection.js
@@ -2,6 +2,7 @@ var expect = require('expect.js');
 var io = require('../');
 var hasCORS = require('has-cors');
 var textBlobBuilder = require('text-blob-builder');
+var env = require('./support/env');
 
 describe('connection', function() {
   this.timeout(70000);
@@ -460,6 +461,9 @@ describe('connection', function() {
 
     it('should get binary data (as an ArrayBuffer)', function(done){
       var socket = io({ forceNew: true });
+      if (env.node) {
+        socket.io.engine.binaryType = 'arraybuffer';
+      }
       socket.emit('doge');
       socket.on('doge', function(buffer){
         expect(buffer instanceof ArrayBuffer).to.be(true);

--- a/test/index.js
+++ b/test/index.js
@@ -1,19 +1,12 @@
 
-var env = require('./support/env');
+require('./support/env');
 
 // whitelist some globals to avoid warnings
-global.__eio = null;
 global.___eio = null;
-global.WEB_SOCKET_LOGGER = null;
-global.WEB_SOCKET_SUPPRESS_CROSS_DOMAIN_SWF_ERROR = null;
-global.WEB_SOCKET_DISABLE_AUTO_INITIALIZATION = null;
-global.WEB_SOCKET_SWF_LOCATION = null;
 
 require('./url');
 
 // browser only tests
-if (env.browser) {
-  require('./connection');
-  require('./socket');
-}
+require('./connection');
+require('./socket');
 

--- a/test/support/env.js
+++ b/test/support/env.js
@@ -4,3 +4,13 @@
 // some tests do not yet work in both
 exports.browser = !!global.window;
 exports.node = !exports.browser;
+
+if (!global.location) {
+  global.location = {
+    protocol: 'http:',
+    host: 'localhost:3210',
+    hostname: 'localhost',
+    port: '3210'
+  };
+}
+

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -2,7 +2,7 @@
 // this is a test server to support tests which make requests
 
 var io = require('socket.io');
-var server = io(process.env.ZUUL_PORT, { pingInterval: 2000 });
+var server = io(process.env.ZUUL_PORT || 3210, { pingInterval: 2000 });
 var expect = require('expect.js');
 
 server.of('/foo').on('connection', function(){


### PR DESCRIPTION
Requires the support server when starting mocha, thus we can tests on node environment too.

Related: https://github.com/socketio/engine.io-client/pull/395