### PR TITLE
Run tests on Android 5 instead of 4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,10 @@ matrix:
     env: BROWSER_NAME=android BROWSER_VERSION=4.2
   - node_js: '0.10'
     env: BROWSER_NAME=android BROWSER_VERSION=4.3
+# It seems Date doesn't work properly on Android 4.4
+# - node_js: '0.10'
+#   env: BROWSER_NAME=android BROWSER_VERSION=4.4
   - node_js: '0.10'
-    env: BROWSER_NAME=android BROWSER_VERSION=4.4
+    env: BROWSER_NAME=android BROWSER_VERSION=5.0
+  - node_js: '0.10'
+    env: BROWSER_NAME=android BROWSER_VERSION=latest


### PR DESCRIPTION
On Android 4.4, It seems there is a bug on `Date` which `.getHours` and `.getTime()` suddenly increase these values 3 hours. Though I couldn't find existing reported issues.

That causes mocha tests fail because of timeout.

https://github.com/mochajs/mocha/blob/master/mocha.js#L4158
```js
   // "duration" becomes like "10802027" and fail. 
    self.duration = new Date() - start;
    finished = true;
    if (!err && self.duration > ms && self._enableTimeouts) {
      err = new Error('timeout of ' + ms + 'ms exceeded. Ensure the done() callback is being called in this test.');
    }
```

I added Android 5 and 5.1(latest) as test targets instead of Android 4.4.