### PR TITLE
Add global object as another fallback.

### DIFF
--- a/support/browserify.js
+++ b/support/browserify.js
@@ -37,5 +37,6 @@ function build(fn){
 
 function glob(){
   return 'typeof self !== "undefined" ? self : '
-    + 'typeof window !== "undefined" ? window : {}';
+    + 'typeof window !== "undefined" ? window : '
+    + 'typeof global !== "undefined" ? global : {}';
 }


### PR DESCRIPTION
In some JavaScript runtimes like NativeScript the `window` or `self` objects are not present, but the `global` is.

NativeScript is using Karma as it its unit test runner and thus relies on socket.io for communication. The socket.io client file is served by Karma and loaded in NativeScript. Up until version 1.4.0 this problem was not visible because the root object was not accessed. However this is not the case anymore with latest json3 changes: https://github.com/NativeScript/socket.io-client/blob/master/socket.io.js#L5220