### PR TITLE
Fix react native crash - use regex.test(userAgent) not userAgent.match(regex)

### DIFF
--- a/socket.io.js
+++ b/socket.io.js
@@ -2982,7 +2982,7 @@ var utf8 = _dereq_('utf8');
  * http://ghinda.net/jpeg-blob-ajax-android/
  */
 
-var isAndroid = navigator.userAgent.match(/Android/i);
+var isAndroid = /Android/i.test(navigator.userAgent);
 
 /**
  * Check if we are running in PhantomJS.


### PR DESCRIPTION
The current test for an Android environment errors if navigator.userAgent is null (e.g. in React Native.)