### PR TITLE
emit sourcemap for socket.io.js

### DIFF
--- a/support/webpack.config.js
+++ b/support/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
   externals: {
     global: glob()
   },
+  devtool: 'source-map',
   module: {
     loaders: [{
       test: /\.js$/,

--- a/support/webpack.config.js
+++ b/support/webpack.config.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   entry: './lib/index.js',
   output: {
@@ -9,7 +8,7 @@ module.exports = {
   externals: {
     global: glob()
   },
-  devtool: 'source-map',
+  devtool: 'cheap-module-source-map',
   module: {
     loaders: [{
       test: /\.js$/,


### PR DESCRIPTION
This adds `socket.io.js.map` as part of the output from `gulp build` task.
There is a corresponding PR in `socket.io` repo to serve the sourcemap: https://github.com/socketio/socket.io/pull/2482
