### PR TITLE
Remove jspm browser config

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "client"
   ],
   "main": "./lib/index",
-  "jspm": {
-    "main": "socket.io.js"
-  },
   "dependencies": {
     "debug": "2.2.0",
     "engine.io-client": "1.6.8",


### PR DESCRIPTION
This jspm configuration stops jspm 0.17 from running socket.io in Node. If we remove this, it will still apply via the jspm override located at https://github.com/jspm/registry/blob/master/package-overrides/github/socketio/socket.io-client%401.3.6.json, so this can continue to work for existing users, but when next published to npm, socket.io can then work for jspm 0.17 users in Node as well.

See https://github.com/jspm/jspm-cli/issues/1676 for more info here.