### PR TITLE
Add nsp prefix to socket.id for generating same ids with server

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -92,9 +92,21 @@ Manager.prototype.emitAll = function () {
 Manager.prototype.updateSocketIds = function () {
   for (var nsp in this.nsps) {
     if (has.call(this.nsps, nsp)) {
-      this.nsps[nsp].id = this.engine.id;
+      this.nsps[nsp].id = this.generateId(nsp);
     }
   }
+};
+
+/**
+ * generate `socket.id` for the given `nsp`
+ *
+ * @param {String} nsp
+ * @return {String}
+ * @api private
+ */
+
+Manager.prototype.generateId = function (nsp) {
+  return nsp + '#' + this.engine.id;
 };
 
 /**
@@ -358,7 +370,7 @@ Manager.prototype.socket = function (nsp) {
     var self = this;
     socket.on('connecting', onConnecting);
     socket.on('connect', function () {
-      socket.id = self.engine.id;
+      socket.id = self.generateId(nsp);
     });
 
     if (this.autoConnect) {

--- a/test/socket.js
+++ b/test/socket.js
@@ -4,11 +4,11 @@ var io = require('../');
 describe('socket', function () {
   this.timeout(70000);
 
-  it('should have an accessible socket id equal to the engine.io socket id', function (done) {
+  it('should have an accessible socket id equal to nsp + the engine.io socket id', function (done) {
     var socket = io({ forceNew: true });
     socket.on('connect', function () {
       expect(socket.id).to.be.ok();
-      expect(socket.id).to.eql(socket.io.engine.id);
+      expect(socket.id).to.eql('/#' + socket.io.engine.id);
       socket.disconnect();
       done();
     });


### PR DESCRIPTION
Fixed https://github.com/socketio/socket.io/issues/2405.
We need to revert https://github.com/socketio/socket.io/pull/2509.
