### PR TITLE
Use `test()` instead of `match()` for consistency and performance

### DIFF
--- a/socket.io.js
+++ b/socket.io.js
@@ -2982,7 +2982,7 @@ var utf8 = _dereq_('utf8');
  * http://ghinda.net/jpeg-blob-ajax-android/
  */
 
-var isAndroid = navigator.userAgent.match(/Android/i);
+var isAndroid = /Android/i.test(navigator.userAgent);
 
 /**
  * Check if we are running in PhantomJS.


### PR DESCRIPTION
Using `test()` instead of `match()` is more performant if all that is needed is to check weather a value exists. Also as a bonus, this resolves an issue that occurs in react-native when in debugging mode. By using `test()`, we no longer will get an error if `navigator.userAgent` is `undefined`.