### PR TITLE
Catch exceptions thrown by WebSocket constructor

### DIFF
--- a/socket.io.js
+++ b/socket.io.js
@@ -4022,7 +4022,7 @@ WS.prototype.doOpen = function(){
   if (this.extraHeaders) {
     opts.headers = this.extraHeaders;
   }
-  
+
   try {
     this.ws = BrowserWebSocket ? new WebSocket(uri) : new WebSocket(uri, protocols, opts);
   } catch (e) {

--- a/socket.io.js
+++ b/socket.io.js
@@ -4022,8 +4022,15 @@ WS.prototype.doOpen = function(){
   if (this.extraHeaders) {
     opts.headers = this.extraHeaders;
   }
-
-  this.ws = BrowserWebSocket ? new WebSocket(uri) : new WebSocket(uri, protocols, opts);
+  
+  try {
+    this.ws = BrowserWebSocket ? new WebSocket(uri) : new WebSocket(uri, protocols, opts);
+  } catch (e) {
+    this.addEventListeners ();
+    this.onError ('websocket error', e);
+    this.onClose ();
+    return;
+  }
 
   if (this.ws.binaryType === undefined) {
     this.supportsBinary = false;


### PR DESCRIPTION
My browser (Google Chrome 51.0.2704.84 (64-bit) Linux) throws net::ERR_NAME_RESOLUTION_FAILED when calling new WebSocket with no Internet connection available. The uncaught exception breaks socket.io's reconnection attempts. This patch solves the problem.