### PR TITLE
Smoother support for events with a variable number of arguments

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -126,6 +126,9 @@ Socket.prototype.send = function () {
  * Override `emit`.
  * If the event is in `events`, it's emitted normally.
  *
+ * Support specifying an optional callback function either as
+ * first or last parameter.
+ *
  * @param {String} event name
  * @return {Socket} self
  * @api public
@@ -146,10 +149,15 @@ Socket.prototype.emit = function (ev) {
   packet.options.compress = !this.flags || false !== this.flags.compress;
 
   // event ack callback
+  var cb;
   if ('function' === typeof args[args.length - 1]) {
+    cb = args.pop();
+  } else if ('function' === typeof args[0]) {
+    cb = args.shift();
+  }
+  if (cb) {
     debug('emitting packet with ack id %d', this.ids);
-    this.acks[this.ids] = args.pop();
-    packet.id = this.ids++;
+    this.acks[packet.id = this.ids++] = cb;
   }
 
   if (this.connected) {

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -282,6 +282,34 @@ Socket.prototype.onevent = function (packet) {
 };
 
 /**
+ * Registers a callback just like Socket.on(), except that the callback
+ * parameter on the incoming event is first instead of last.
+ * If there is no callback, the first parameter on the incoming event
+ * is zero.
+ *
+ * This simplifies implementations where the number of parameters
+ * on the event is variable.
+ *
+ * @param {String} event name
+ * @param {function} callback function
+ * @return {Socket} self
+ * @api public
+ */
+
+Socket.prototype.cbon = function (event, fn) {
+  function cb1st() {
+    var cb, args = toArray(arguments);
+
+    if ('function' === typeof args[args.length-1]) {
+      cb = args.pop();
+    }
+    args.unshift(cb);
+    return fn.apply(this, args);
+  };
+  return this.on(event, cb1st);
+};
+
+/**
  * Produces an ack callback to emit with an event.
  *
  * @api private


### PR DESCRIPTION
Introduces Socket.cbon() so that the callback function can rely on the first argument being either undefined or the callback function.

Alters Socket.emit() to support specifying the callback function not only as the last argument, but optionally instead as the first argument.  This naturally aligns with the vararg-friendly API provided by cbon().

Both suggested additions allow for sane support of vararg functions without jumping through JavaScript API-hoops.
