### PR TITLE
bump engine.io-client to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "./lib/index",
   "dependencies": {
     "debug": "2.2.0",
-    "engine.io-client": "1.6.11",
+    "engine.io-client": "1.7.0",
     "component-bind": "1.0.0",
     "component-emitter": "1.2.0",
     "object-component": "0.0.3",


### PR DESCRIPTION
Working on clearing dependency advisories reported by snyk.io ( https://snyk.io/test/npm/socket.io-client/1.4.8 ).  I think the underlying vulnerability was already addressed before, now just doing a version bump so the old version of ws is no longer in the dependency chain.