### PR TITLE
Disable AMD for json3

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "gulp-mocha": "2.2.0",
     "gulp-task-listing": "1.0.1",
     "has-cors": "1.1.0",
+    "imports-loader": "^0.6.5",
     "istanbul": "0.4.2",
     "mocha": "2.3.4",
     "socket.io": "1.5.0",

--- a/support/webpack.config.js
+++ b/support/webpack.config.js
@@ -14,9 +14,10 @@ module.exports = {
       test: /\.js$/,
       exclude: /(node_modules|bower_components)/,
       loader: 'babel', // 'babel-loader' is also a legal name to reference
-      query: {
-        presets: ['es2015']
-      }
+      query: { presets: ['es2015'] }
+    }, {
+      test: /\json3.js/,
+      loader: 'imports?define=>false'
     }]
   }
 };


### PR DESCRIPTION
Saying to Webpack don't use the AMD style for json3 dependency

Fix #1004