### PR TITLE
Provide a slim build without JSON3 and debug

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,12 @@ const BUILD_TARGET_DIR = './dist/';
 
 gulp.task('build', function () {
   return gulp.src('lib/*.js')
-    .pipe(webpack(require('./support/webpack.config.js')))
+    .pipe(webpack({
+      config: [
+        require('./support/webpack.config.js'),
+        require('./support/webpack.config.slim.js')
+      ]
+    }))
     .pipe(minify({
       ext: {
         src: '.js',

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "socket.io": "1.6.0",
     "text-blob-builder": "0.0.1",
     "uglify-js": "2.6.1",
-    "webpack-stream": "3.1.0",
+    "webpack-stream": "3.2.0",
     "zuul": "3.11.0",
     "zuul-builder-webpack": "1.1.0",
     "zuul-ngrok": "4.0.0"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "istanbul": "0.4.2",
     "mocha": "2.3.4",
     "socket.io": "1.6.0",
+    "strip-loader": "0.1.2",
     "text-blob-builder": "0.0.1",
     "uglify-js": "2.6.1",
     "webpack-stream": "3.2.0",

--- a/support/noop.js
+++ b/support/noop.js
@@ -1,2 +1,2 @@
 
-module.exports = function() { return function () {} };
+module.exports = function () { return function () {}; };

--- a/support/noop.js
+++ b/support/noop.js
@@ -1,0 +1,2 @@
+
+module.exports = function() { return function () {} };

--- a/support/webpack.config.slim.js
+++ b/support/webpack.config.slim.js
@@ -1,16 +1,21 @@
 
+var webpack = require('webpack');
+
 module.exports = {
-  name: 'default',
+  name: 'slim',
   entry: './lib/index.js',
   output: {
     library: 'io',
     libraryTarget: 'umd',
-    filename: 'socket.io.js'
+    filename: 'socket.io.slim.js'
   },
   externals: {
     global: glob()
   },
   devtool: 'cheap-module-source-map',
+  plugins: [
+    new webpack.NormalModuleReplacementPlugin(/(debug|json3)/, process.cwd() + '/support/noop.js')
+  ],
   module: {
     loaders: [{
       test: /\.js$/,
@@ -20,6 +25,9 @@ module.exports = {
     }, {
       test: /\json3.js/,
       loader: 'imports?define=>false'
+    }, {
+      test: /\.js$/,
+      loader: "strip-loader?strip[]=debug"
     }]
   }
 };

--- a/support/webpack.config.slim.js
+++ b/support/webpack.config.slim.js
@@ -27,7 +27,7 @@ module.exports = {
       loader: 'imports?define=>false'
     }, {
       test: /\.js$/,
-      loader: "strip-loader?strip[]=debug"
+      loader: 'strip-loader?strip[]=debug'
     }]
   }
 };


### PR DESCRIPTION
Following the discussion here https://github.com/socketio/socket.io-client/issues/1019:

```
Child default:
    Version: webpack 1.13.3
               Asset    Size  Chunks             Chunk Names
        socket.io.js  212 kB       0  [emitted]  main
    socket.io.js.map  256 kB       0  [emitted]  main
Child slim:
    Version: webpack 1.13.3
                    Asset    Size  Chunks             Chunk Names
        socket.io.slim.js  136 kB       0  [emitted]  main
    socket.io.slim.js.map  168 kB       0  [emitted]  main
```