### PR TITLE
Fix json import in slim build

### DIFF
--- a/support/webpack.config.slim.js
+++ b/support/webpack.config.slim.js
@@ -15,7 +15,7 @@ module.exports = {
   },
   devtool: 'cheap-module-source-map',
   plugins: [
-    new webpack.NormalModuleReplacementPlugin(/(debug|json3)/, process.cwd() + '/support/noop.js')
+    new webpack.NormalModuleReplacementPlugin(/debug/, process.cwd() + '/support/noop.js')
   ],
   module: {
     loaders: [{

--- a/support/webpack.config.slim.js
+++ b/support/webpack.config.slim.js
@@ -10,7 +10,8 @@ module.exports = {
     filename: 'socket.io.slim.js'
   },
   externals: {
-    global: glob()
+    global: glob(),
+    json3: 'JSON'
   },
   devtool: 'cheap-module-source-map',
   plugins: [


### PR DESCRIPTION
Fixes https://github.com/socketio/socket.io-client/issues/1034

Since `var json = require('json3');` returns an empty callback (`/support/noop.js`), the slim build throws: `Uncaught TypeError: json.stringify is not a function`.
