### PR TITLE
Speed up lint by avoiding '**/*.js' matching pattern

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,10 +55,10 @@ gulp.task('test-zuul', testZuul);
 
 gulp.task('lint', function () {
   return gulp.src([
-    '**/*.js',
-    '!node_modules/**',
-    '!coverage/**',
-    '!dist/**'
+    '*.js',
+    'lib/**/*.js',
+    'test/**/*.js',
+    'support/**/*.js'
   ])
     .pipe(eslint())
     .pipe(eslint.format())


### PR DESCRIPTION
Before
```js
> gulp test

[02:34:42] Using gulpfile ~/git/socket.io-client/gulpfile.js
[02:34:42] Starting 'lint'...
[02:35:06] Finished 'lint' after 25 s
[02:35:06] Starting 'test'...
```
After
```js
> gulp test

[02:35:34] Using gulpfile ~/git/socket.io-client/gulpfile.js
[02:35:34] Starting 'lint'...
[02:35:37] Finished 'lint' after 2.43 s
[02:35:37] Starting 'test'...
```