### PR TITLE
Add nsp prefix to socket.id

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -92,9 +92,21 @@ Manager.prototype.emitAll = function () {
 Manager.prototype.updateSocketIds = function () {
   for (var nsp in this.nsps) {
     if (has.call(this.nsps, nsp)) {
-      this.nsps[nsp].id = this.engine.id;
+      this.nsps[nsp].id = this.generateId(nsp);
     }
   }
+};
+
+/**
+ * generate `socket.id` for the given `nsp`
+ *
+ * @param {String} nsp
+ * @return {String}
+ * @api private
+ */
+
+Manager.prototype.generateId = function (nsp) {
+  return nsp + '#' + this.engine.id;
 };
 
 /**
@@ -358,7 +370,7 @@ Manager.prototype.socket = function (nsp, opts) {
     var self = this;
     socket.on('connecting', onConnecting);
     socket.on('connect', function () {
-      socket.id = self.engine.id;
+      socket.id = self.generateId(nsp);
     });
 
     if (this.autoConnect) {

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -106,7 +106,7 @@ Manager.prototype.updateSocketIds = function () {
  */
 
 Manager.prototype.generateId = function (nsp) {
-  return nsp + '#' + this.engine.id;
+  return (nsp === '/' ? '' : (nsp + '#')) + this.engine.id;
 };
 
 /**

--- a/test/socket.js
+++ b/test/socket.js
@@ -4,11 +4,21 @@ var io = require('../');
 describe('socket', function () {
   this.timeout(70000);
 
-  it('should have an accessible socket id equal to nsp + the engine.io socket id', function (done) {
+  it('should have an accessible socket id equal to the server-side socket id (default namespace)', function (done) {
     var socket = io({ forceNew: true });
     socket.on('connect', function () {
       expect(socket.id).to.be.ok();
-      expect(socket.id).to.eql('/#' + socket.io.engine.id);
+      expect(socket.id).to.eql(socket.io.engine.id);
+      socket.disconnect();
+      done();
+    });
+  });
+
+  it('should have an accessible socket id equal to the server-side socket id (custom namespace)', function (done) {
+    var socket = io('/foo', { forceNew: true });
+    socket.on('connect', function () {
+      expect(socket.id).to.be.ok();
+      expect(socket.id).to.eql('/foo#' + socket.io.engine.id);
       socket.disconnect();
       done();
     });

--- a/test/socket.js
+++ b/test/socket.js
@@ -4,11 +4,11 @@ var io = require('../');
 describe('socket', function () {
   this.timeout(70000);
 
-  it('should have an accessible socket id equal to the engine.io socket id', function (done) {
+  it('should have an accessible socket id equal to nsp + the engine.io socket id', function (done) {
     var socket = io({ forceNew: true });
     socket.on('connect', function () {
       expect(socket.id).to.be.ok();
-      expect(socket.id).to.eql(socket.io.engine.id);
+      expect(socket.id).to.eql('/#' + socket.io.engine.id);
       socket.disconnect();
       done();
     });


### PR DESCRIPTION
Following https://github.com/socketio/socket.io-client/pull/959

Currently, the socket.id for a non-default namespace is different on the server / on the client (`e9232kh` on the client, no matter which namespace, but  `/<nsp>#e9232kh` on the server). That commit fixes that.

Related: https://github.com/socketio/socket.io/pull/2509/files