### PR TITLE
[fix] Bump socket.io-parser to version 2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "indexof": "0.0.1",
     "object-component": "0.0.3",
     "parseuri": "0.0.5",
-    "socket.io-parser": "2.3.1",
+    "socket.io-parser": "2.3.2",
     "to-array": "0.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
External closure compiler are failing on minify due to the usage of reserved keywords.

### New behaviour
External closure compiler should not fail any longer, because the usage of reserved keywords has been removed within the updated dependency a while ago.

### Other information (e.g. related issues)
#807 