### PR TITLE
Bump engine.io-client to version 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "component-bind": "1.0.0",
     "component-emitter": "1.2.1",
     "debug": "2.3.3",
-    "engine.io-client": "2.0.0",
+    "engine.io-client": "2.0.2",
     "has-binary": "0.1.7",
     "indexof": "0.0.1",
     "object-component": "0.0.3",


### PR DESCRIPTION
Includes the following (from engine.io-client changelog):

* [chore] Bump ws to version 1.1.2 (vulnerability fix) ([#539](https://github.com/socketio/engine.io-client/issues/539))
* [fix] Fix extraHeaders option in browser ([#536](https://github.com/socketio/engine.io-client/issues/536))

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour

Socket.io-client installs version 2.0.0 of the engine.io-client dependency.

### New behaviour

Socket.io-client installs version 2.0.2 of the engine.io-client dependency.

### Other information (e.g. related issues)

[As with socket.io](https://github.com/socketio/socket.io/pull/2864), it might be worth considering changing this dependency to at least use a ~ (i.e. `'engine.io-client': '~2.0.0'`, but again, I get it.
