### PR TITLE
Updated formatting on API.md

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -73,7 +73,7 @@ See [new Manager(url[, options])](#managerurl-options) for available `options`.
 
   - `url` _(String)_
   - `options` _(Object)_
-    - `path` _(String)_ name of the path that is captured on the server side (`/socket.io`)
+    - `path` _(String)_ name of the path that is captured on the server side (`/socket.io`)
     - `reconnection` _(Boolean)_ whether to reconnect automatically (`true`)
     - `reconnectionAttempts` _(Number)_ number of reconnection attempts before giving up (`Infinity`)
     - `reconnectionDelay` _(Number)_ how long to initially wait before attempting a new


### PR DESCRIPTION



*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Formatting was broken on the *Manager* section, under "new Manager / options" object. It's not a big deal, but because of this, I was not being able to find the specific `path` property, which was critical for my own socket.io implementation.

### New behaviour
`path` property will be displayed into a new line, as part of the properties list for the `options` object.

### Other information (e.g. related issues)
The diff view may not show the actual results; you'd need to see the API.md as parsed html.

