### PR TITLE
concat-stream known to be vulnerable prior 1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-loader": "6.2.1",
     "babel-preset-es2015": "6.3.13",
     "base64-arraybuffer": "0.1.5",
-    "concat-stream": "1.5.1",
+    "concat-stream": "1.5.2",
     "derequire": "2.0.3",
     "eslint-config-standard": "4.4.0",
     "eslint-plugin-standard": "1.3.1",


### PR DESCRIPTION
https://snyk.io/vuln/npm:concat-stream:20160901?utm_source=slack


*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour

concat-stream known to be vulnerable

### New behaviour

concat-stream no longer vulnerable

### Other information (e.g. related issues)

https://snyk.io/vuln/npm:concat-stream:20160901?utm_source=slack

