### PR TITLE
`new io.Manager(...)` returns `Manager`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -87,7 +87,7 @@ See [new Manager(url[, options])](#managerurl-options) for available `options`.
       and `connect_timeout` events are emitted (`20000`)
     - `autoConnect` _(Boolean)_ by setting this false, you have to call `manager.open`
       whenever you decide it's appropriate
-  - **Returns** `Socket`
+  - **Returns** `Manager`
 
 The `options` are also passed to `engine.io-client` upon initialization of the underlying `Socket`. See the available `options` [here](https://github.com/socketio/engine.io-client#methods).
 


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] typo

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


