### PR TITLE
Bump engine.io to version 3.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-- '0.10'
-- '0.12'
 - '4'
 - '6'
 - '7'
@@ -30,7 +28,7 @@ matrix:
     env: BROWSER_NAME=ie BROWSER_VERSION=10
   - node_js: 'node'
     env: BROWSER_NAME=ie BROWSER_VERSION=11
-  - node_js: '0.12'
+  - node_js: 'node'
     env: BROWSER_NAME=microsoftedge BROWSER_VERSION=latest
   - node_js: 'node'
     env: BROWSER_NAME=iphone BROWSER_VERSION=8.4

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "component-bind": "1.0.0",
     "component-emitter": "1.2.1",
     "debug": "2.6.4",
-    "engine.io-client": "2.0.2",
+    "engine.io-client": "~3.1.0",
     "has-cors": "1.1.0",
     "indexof": "0.0.1",
     "object-component": "0.0.3",


### PR DESCRIPTION
Also drops nodejs versions 0.10 and 0.12.