### PR TITLE
do not update the opts.query reference

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -65,7 +65,9 @@ Creates a new `Manager` for the given URL, and attempts to reuse an existing `Ma
 
 A new `Socket` instance is returned for the namespace specified by the pathname in the URL, defaulting to `/`. For example, if the `url` is `http://localhost/users`, a transport connection will be established to `http://localhost` and a Socket.IO connection will be established to `/users`.
 
-See [new Manager(url[, options])](#managerurl-options) for available `options`.
+Query parameters can also be provided, either with the `query` option or directly in the url (example: `http://localhost/users?token=abc`).
+
+See [new Manager(url[, options])](#new-managerurl-options) for available `options`.
 
 ### Manager
 
@@ -87,6 +89,7 @@ See [new Manager(url[, options])](#managerurl-options) for available `options`.
       and `connect_timeout` events are emitted (`20000`)
     - `autoConnect` _(Boolean)_ by setting this false, you have to call `manager.open`
       whenever you decide it's appropriate
+    - `query` _(Object)_: additional query parameters that are sent when connecting a namespace (then found in `socket.handshake.query` object on the server-side)
   - **Returns** `Manager`
 
 The `options` are also passed to `engine.io-client` upon initialization of the underlying `Socket`. See the available `options` [here](https://github.com/socketio/engine.io-client#methods).

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,25 +63,10 @@ function lookup (uri, opts) {
   }
   if (parsed.query && !opts.query) {
     opts.query = parsed.query;
-  } else if (opts && 'object' === typeof opts.query) {
-    opts.query = encodeQueryString(opts.query);
   }
   return io.socket(parsed.path, opts);
 }
-/**
- *  Helper method to parse query objects to string.
- * @param {object} query
- * @returns {string}
- */
-function encodeQueryString (obj) {
-  var str = [];
-  for (var p in obj) {
-    if (obj.hasOwnProperty(p)) {
-      str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]));
-    }
-  }
-  return str.join('&');
-}
+
 /**
  * Protocol version.
  *

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -9,6 +9,7 @@ var toArray = require('to-array');
 var on = require('./on');
 var bind = require('component-bind');
 var debug = require('debug')('socket.io-client:socket');
+var parseqs = require('parseqs');
 
 /**
  * Module exports.
@@ -184,7 +185,9 @@ Socket.prototype.onopen = function () {
   // write connect packet if necessary
   if ('/' !== this.nsp) {
     if (this.query) {
-      this.packet({type: parser.CONNECT, query: this.query});
+      var query = typeof this.query === 'object' ? parseqs.encode(this.query) : this.query;
+      debug('sending connect packet with query %s', query);
+      this.packet({type: parser.CONNECT, query: query});
     } else {
       this.packet({type: parser.CONNECT});
     }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "has-cors": "1.1.0",
     "indexof": "0.0.1",
     "object-component": "0.0.3",
+    "parseqs": "0.0.5",
     "parseuri": "0.0.5",
     "socket.io-parser": "~3.1.1",
     "to-array": "0.1.4"

--- a/test/socket.js
+++ b/test/socket.js
@@ -106,16 +106,58 @@ describe('socket', function () {
     });
   });
 
-  it('should store query string as a property', function (done) {
-    var socket = io('/abc', {query: {a: 'b'}}); // passes in as a query obj
-    var socket2 = io('/abcd?b=c&d=e'); // passes in as a query string
-    var socket3 = io('/abc', {query: {'&a': '&=?a'}}); // checks that it encodes a string
-    expect(socket.query).to.be('a=b');
-    expect(socket2.query).to.be('b=c&d=e');
-    expect(socket3.query).to.be('%26a=%26%3D%3Fa');
-    socket.disconnect();
-    socket2.disconnect();
-    socket3.disconnect();
-    done();
+  describe('query option', function () {
+    it('should accept an object (default namespace)', function (done) {
+      var socket = io('/', { forceNew: true, query: { e: 'f' } });
+
+      socket.emit('getHandshake', function (handshake) {
+        console.log('getHandhskae', handshake);
+        expect(handshake.query.e).to.be('f');
+        socket.disconnect();
+        done();
+      });
+    });
+
+    it('should accept a query string (default namespace)', function (done) {
+      var socket = io('/?c=d', { forceNew: true });
+
+      socket.emit('getHandshake', function (handshake) {
+        console.log('getHandhskae', handshake);
+        expect(handshake.query.c).to.be('d');
+        socket.disconnect();
+        done();
+      });
+    });
+
+    it('should accept an object', function (done) {
+      var socket = io('/abc', {query: {a: 'b'}});
+
+      socket.on('handshake', function (handshake) {
+        expect(handshake.query.a).to.be('b');
+        socket.disconnect();
+        done();
+      });
+    });
+
+    it('should accept a query string', function (done) {
+      var socket = io('/abc?b=c&d=e');
+
+      socket.on('handshake', function (handshake) {
+        expect(handshake.query.b).to.be('c');
+        expect(handshake.query.d).to.be('e');
+        socket.disconnect();
+        done();
+      });
+    });
+
+    it('should properly encode the parameters', function (done) {
+      var socket = io('/abc', {query: {'&a': '&=?a'}});
+
+      socket.on('handshake', function (handshake) {
+        expect(handshake.query['&a']).to.be('&=?a');
+        socket.disconnect();
+        done();
+      });
+    });
   });
 });

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -21,6 +21,10 @@ server.of('/asd').on('connection', function () {
   // register namespace
 });
 
+server.of('/abc').on('connection', function (socket) {
+  socket.emit('handshake', socket.handshake);
+});
+
 server.on('connection', function (socket) {
   // simple test
   socket.on('hi', function () {
@@ -127,5 +131,9 @@ server.on('connection', function (socket) {
   socket.on('getbin', function () {
     var buf = new Buffer('asdfasdf', 'utf8');
     socket.emit('takebin', buf);
+  });
+
+  socket.on('getHandshake', function (cb) {
+    cb(socket.handshake);
   });
 });


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Currently passing `query: { a: 'b' }` is replaced on initialization by `query: 'a=b'`.

### New behaviour


### Other information (e.g. related issues)

Fixes https://github.com/socketio/socket.io-client/issues/1086
Closes https://github.com/socketio/socket.io-client/pull/1087
