### PR TITLE
ensure reconnectionAttempts accepts 0

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -45,8 +45,12 @@ function Manager (uri, opts) {
   this.nsps = {};
   this.subs = [];
   this.opts = opts;
+  var reconnectionAttempts = opts.reconnectionAttempts;
+  if (typeof reconnectionAttempts !== 'number' || reconnectionAttempts < 0) {
+    reconnectionAttempts = Infinity;
+  }
   this.reconnection(opts.reconnection !== false);
-  this.reconnectionAttempts(opts.reconnectionAttempts || Infinity);
+  this.reconnectionAttempts(reconnectionAttempts);
   this.reconnectionDelay(opts.reconnectionDelay || 1000);
   this.reconnectionDelayMax(opts.reconnectionDelayMax || 5000);
   this.randomizationFactor(opts.randomizationFactor || 0.5);

--- a/test/index.js
+++ b/test/index.js
@@ -5,8 +5,8 @@ require('./support/env');
 global.___eio = null;
 
 require('./url');
+require('./manager');
 
 // browser only tests
 require('./connection');
 require('./socket');
-

--- a/test/manager.js
+++ b/test/manager.js
@@ -1,0 +1,17 @@
+var expect = require('expect.js');
+var Manager = require('../lib/manager');
+
+describe('manager', function () {
+  it('should allow setting 0 for reconnectionAttempts', function () {
+    var man = new Manager('/test', {
+      reconnectionAttempts: 0
+    });
+    expect(man.reconnectionAttempts()).to.equal(0);
+  });
+
+  it('defaults to Infinity', function () {
+    var man = new Manager('/test');
+
+    expect(man.reconnectionAttempts()).to.equal(Infinity);
+  });
+});

--- a/test/socket.js
+++ b/test/socket.js
@@ -111,7 +111,6 @@ describe('socket', function () {
       var socket = io('/', { forceNew: true, query: { e: 'f' } });
 
       socket.emit('getHandshake', function (handshake) {
-        console.log('getHandhskae', handshake);
         expect(handshake.query.e).to.be('f');
         socket.disconnect();
         done();
@@ -122,7 +121,6 @@ describe('socket', function () {
       var socket = io('/?c=d', { forceNew: true });
 
       socket.emit('getHandshake', function (handshake) {
-        console.log('getHandhskae', handshake);
         expect(handshake.query.c).to.be('d');
         socket.disconnect();
         done();


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

`Manager` will not respect passing in 0 because of how the conditional assignment was working. This led to unexpected behavior while I was debugging a socket.io connection.
### New behaviour
If the option is not a number or is less then 0, then it will default to `Infinity`. (which it was attempting to do before I gather). If the value is a number, it will be respected.

### Other information (e.g. related issues)


