### PR TITLE
add explicit documentation for websocket transport

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -177,7 +177,7 @@ socket.on('reconnect_attempt', () => {
 
 ##### With `extraHeaders`
 
-Note: will only work if `polling` transport is enabled (which is the default)
+This only works if `polling` transport is enabled (which is the default). Custom headers will not be appended when using `websocket` as the transport. This happens because the WebSocket handshake does not honor custom headers. (For background see the [WebSocket protocol RFC](https://tools.ietf.org/html/rfc6455#section-4))
 
 ```js
 const socket = io({


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
addresses #1127 

### New behaviour


### Other information (e.g. related issues)
upon reading https://tools.ietf.org/html/rfc6455#section-4 point 12, it looks like the spec allows for additional `Authorization` headers. Setting those seems like a different topic so didn't make sense to include in the main note.

