### PR TITLE
Added callback to disconnect/close function

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -496,15 +496,16 @@ Sets a modifier for a subsequent event emission that the event data will only be
 socket.compress(false).emit('an event', { some: 'data' });
 ```
 
-#### socket.close()
+#### socket.close(callback)
 
+  - `callback` _(Function)_
   - **Returns** `Socket`
 
-Disconnects the socket manually.
+Disconnects the socket manually and triggers callback once it's done.
 
-#### socket.disconnect()
+#### socket.disconnect(callback)
 
-Synonym of [socket.close()](#socketclose).
+Synonym of [socket.close(callback)](#socketclose).
 
 #### Event: 'connect'
 

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -382,12 +382,13 @@ Socket.prototype.destroy = function () {
 /**
  * Disconnects the socket manually.
  *
+ * @param {Function} callback
  * @return {Socket} self
  * @api public
  */
 
 Socket.prototype.close =
-Socket.prototype.disconnect = function () {
+Socket.prototype.disconnect = function (fn) {
   if (this.connected) {
     debug('performing disconnect (%s)', this.nsp);
     this.packet({ type: parser.DISCONNECT });
@@ -399,6 +400,9 @@ Socket.prototype.disconnect = function () {
   if (this.connected) {
     // fire events
     this.onclose('io client disconnect');
+  }
+  if (typeof fn === 'function') {
+    fn();
   }
   return this;
 };


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Currently the client disconnects without notifying the application

### New behaviour
Added a callback to close function to be used as a way of figuring out once client has finished disconnecting

### Other information (e.g. related issues)
I am not sure if this is actually done correctly, I am relatively new to WebSockets, if this doesn't result in the desired new behaviour I am happy to modify/update after any given input/guidance
This was my take on resolving this issue https://github.com/socketio/socket.io/issues/3018
