### PR TITLE
Include jspm package configuration to allow for easier jspm installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,12 @@
     "lib/",
     "dist/"
   ],
+  "jspm": {
+    "main": "socket.io.js",
+    "directories": {
+      "lib": "dist"
+    }
+  },
   "dependencies": {
     "backo2": "1.0.2",
     "base64-arraybuffer": "0.1.5",


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour
socket.io-client used to have a jspm package definition but has since taken that out. This makes jspm installs not available or otherwise (when performed via npm) include too many unnecessary dependencies.

### New behaviour
Adds jspm package definition to simply include the dist folder and sets the main file to socket.io.js. 

