### PR TITLE
Build Unminified Distribution Files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,9 @@ gulp.task('build', function () {
     .pipe(webpack({
       config: [
         require('./support/webpack.config.js'),
-        require('./support/webpack.config.slim.js')
+        require('./support/webpack.config.dev.js'),
+        require('./support/webpack.config.slim.js'),
+        require('./support/webpack.config.slim.dev.js')
       ]
     }))
     .pipe(gulp.dest(BUILD_TARGET_DIR));

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "socket.io": "2.0.4",
     "strip-loader": "0.1.2",
     "text-blob-builder": "0.0.1",
+    "webpack-merge": "4.1.2",
     "webpack-stream": "3.2.0",
     "zuul": "^3.11.1  ",
     "zuul-builder-webpack": "^1.2.0",

--- a/support/webpack.config.dev.js
+++ b/support/webpack.config.dev.js
@@ -1,0 +1,39 @@
+
+var webpack = require('webpack');
+
+module.exports = {
+  name: 'default',
+  entry: './lib/index.js',
+  output: {
+    library: 'io',
+    libraryTarget: 'umd',
+    filename: 'socket.io.dev.js'
+  },
+  externals: {
+    global: glob()
+  },
+  devtool: 'source-map',
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      exclude: /(node_modules|bower_components)/,
+      loader: 'babel', // 'babel-loader' is also a legal name to reference
+      query: { presets: ['es2015'] }
+    }, {
+      test: /\json3.js/,
+      loader: 'imports?define=>false'
+    }]
+  }
+};
+
+/**
+ * Populates `global`.
+ *
+ * @api private
+ */
+
+function glob () {
+  return 'typeof self !== "undefined" ? self : ' +
+    'typeof window !== "undefined" ? window : ' +
+    'typeof global !== "undefined" ? global : {}';
+}

--- a/support/webpack.config.js
+++ b/support/webpack.config.js
@@ -1,18 +1,13 @@
-
 var webpack = require('webpack');
+var merge = require('webpack-merge');
+var baseConfig = require('./webpack.config.dev.js')
 
-module.exports = {
-  name: 'default',
-  entry: './lib/index.js',
+module.exports = merge(baseConfig, {
   output: {
     library: 'io',
     libraryTarget: 'umd',
     filename: 'socket.io.js'
   },
-  externals: {
-    global: glob()
-  },
-  devtool: 'source-map',
   plugins: [
     new webpack.optimize.UglifyJsPlugin({
       compress: {
@@ -27,27 +22,4 @@ module.exports = {
       }
     })
   ],
-  module: {
-    loaders: [{
-      test: /\.js$/,
-      exclude: /(node_modules|bower_components)/,
-      loader: 'babel', // 'babel-loader' is also a legal name to reference
-      query: { presets: ['es2015'] }
-    }, {
-      test: /\json3.js/,
-      loader: 'imports?define=>false'
-    }]
-  }
-};
-
-/**
- * Populates `global`.
- *
- * @api private
- */
-
-function glob () {
-  return 'typeof self !== "undefined" ? self : ' +
-    'typeof window !== "undefined" ? window : ' +
-    'typeof global !== "undefined" ? global : {}';
-}
+});

--- a/support/webpack.config.slim.dev.js
+++ b/support/webpack.config.slim.dev.js
@@ -1,0 +1,46 @@
+
+var webpack = require('webpack');
+
+module.exports = {
+  name: 'slim',
+  entry: './lib/index.js',
+  output: {
+    library: 'io',
+    libraryTarget: 'umd',
+    filename: 'socket.io.slim.dev.js'
+  },
+  externals: {
+    global: glob(),
+    json3: 'JSON'
+  },
+  devtool: 'source-map',
+  plugins: [
+    new webpack.NormalModuleReplacementPlugin(/debug/, process.cwd() + '/support/noop.js'),
+  ],
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      exclude: /(node_modules|bower_components)/,
+      loader: 'babel', // 'babel-loader' is also a legal name to reference
+      query: { presets: ['es2015'] }
+    }, {
+      test: /\json3.js/,
+      loader: 'imports?define=>false'
+    }, {
+      test: /\.js$/,
+      loader: 'strip-loader?strip[]=debug'
+    }]
+  }
+};
+
+/**
+ * Populates `global`.
+ *
+ * @api private
+ */
+
+function glob () {
+  return 'typeof self !== "undefined" ? self : ' +
+    'typeof window !== "undefined" ? window : ' +
+    'typeof global !== "undefined" ? global : {}';
+}

--- a/support/webpack.config.slim.js
+++ b/support/webpack.config.slim.js
@@ -1,47 +1,14 @@
-
 var webpack = require('webpack');
+var merge = require('webpack-merge');
+var baseConfig = require('./webpack.config.slim.dev.js')
 
-module.exports = {
-  name: 'slim',
-  entry: './lib/index.js',
+module.exports = merge(baseConfig, {
   output: {
     library: 'io',
     libraryTarget: 'umd',
     filename: 'socket.io.slim.js'
   },
-  externals: {
-    global: glob(),
-    json3: 'JSON'
-  },
-  devtool: 'source-map',
   plugins: [
-    new webpack.NormalModuleReplacementPlugin(/debug/, process.cwd() + '/support/noop.js'),
     new webpack.optimize.UglifyJsPlugin()
   ],
-  module: {
-    loaders: [{
-      test: /\.js$/,
-      exclude: /(node_modules|bower_components)/,
-      loader: 'babel', // 'babel-loader' is also a legal name to reference
-      query: { presets: ['es2015'] }
-    }, {
-      test: /\json3.js/,
-      loader: 'imports?define=>false'
-    }, {
-      test: /\.js$/,
-      loader: 'strip-loader?strip[]=debug'
-    }]
-  }
-};
-
-/**
- * Populates `global`.
- *
- * @api private
- */
-
-function glob () {
-  return 'typeof self !== "undefined" ? self : ' +
-    'typeof window !== "undefined" ? window : ' +
-    'typeof global !== "undefined" ? global : {}';
-}
+});


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour
Socket.io-client 2.x.x dropped support for including an unminified build as part of the bower package. As part of our build process, we prefer to minify all files ourselves, which is no longer possible with the default package.

### New behaviour
This PR brings back the build behaviour from pre-2.x.x.

### Other information (e.g. related issues)
Fixes #1161

