### PR TITLE
[feat] Add a 'binary' flag

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -41,6 +41,7 @@
     - [socket.emit(eventName[, ...args][, ack])](#socketemiteventname-args-ack)
     - [socket.on(eventName, callback)](#socketoneventname-callback)
     - [socket.compress(value)](#socketcompressvalue)
+    - [socket.binary(value)](#socketbinaryvalue)
     - [socket.close()](#socketclose)
     - [socket.disconnect()](#socketdisconnect)
     - [Event: 'connect'](#event-connect)
@@ -524,6 +525,14 @@ Sets a modifier for a subsequent event emission that the event data will only be
 
 ```js
 socket.compress(false).emit('an event', { some: 'data' });
+```
+
+#### socket.binary(value)
+
+Specifies whether the emitted data contains binary. Increases performance when specified. Can be `true` or `false`.
+
+```js
+socket.binary(false).emit('an event', { some: 'data' });
 ```
 
 #### socket.close()

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -10,6 +10,7 @@ var on = require('./on');
 var bind = require('component-bind');
 var debug = require('debug')('socket.io-client:socket');
 var parseqs = require('parseqs');
+var hasBin = require('has-binary2');
 
 /**
  * Module exports.
@@ -62,6 +63,7 @@ function Socket (io, nsp, opts) {
   this.sendBuffer = [];
   this.connected = false;
   this.disconnected = true;
+  this.flags = {};
   if (opts && opts.query) {
     this.query = opts.query;
   }
@@ -138,7 +140,10 @@ Socket.prototype.emit = function (ev) {
   }
 
   var args = toArray(arguments);
-  var packet = { type: parser.EVENT, data: args };
+  var packet = {
+    type: (this.flags.binary !== undefined ? this.flags.binary : hasBin(args)) ? parser.BINARY_EVENT : parser.EVENT,
+    data: args
+  };
 
   packet.options = {};
   packet.options.compress = !this.flags || false !== this.flags.compress;
@@ -156,7 +161,7 @@ Socket.prototype.emit = function (ev) {
     this.sendBuffer.push(packet);
   }
 
-  delete this.flags;
+  this.flags = {};
 
   return this;
 };
@@ -290,7 +295,7 @@ Socket.prototype.ack = function (id) {
     debug('sending ack %j', args);
 
     self.packet({
-      type: parser.ACK,
+      type: hasBin(args) ? parser.BINARY_ACK : parser.ACK,
       id: id,
       data: args
     });
@@ -412,7 +417,19 @@ Socket.prototype.disconnect = function () {
  */
 
 Socket.prototype.compress = function (compress) {
-  this.flags = this.flags || {};
   this.flags.compress = compress;
+  return this;
+};
+
+/**
+ * Sets the binary flag
+ *
+ * @param {Boolean} whether the emitted data contains binary
+ * @return {Socket} self
+ * @api public
+ */
+
+Socket.prototype.binary = function (binary) {
+  this.flags.binary = binary;
   return this;
 };

--- a/package.json
+++ b/package.json
@@ -21,12 +21,13 @@
     "component-emitter": "1.2.1",
     "debug": "~3.1.0",
     "engine.io-client": "~3.2.0",
+    "has-binary2": "~1.0.2",
     "has-cors": "1.1.0",
     "indexof": "0.0.1",
     "object-component": "0.0.3",
     "parseqs": "0.0.5",
     "parseuri": "0.0.5",
-    "socket.io-parser": "3.1.2",
+    "socket.io-parser": "~3.2.0",
     "to-array": "0.1.4"
   },
   "devDependencies": {
@@ -48,7 +49,7 @@
     "imports-loader": "^0.7.1",
     "istanbul": "^0.4.5",
     "mocha": "^3.3.0",
-    "socket.io": "2.0.4",
+    "socket.io": "socketio/socket.io",
     "socket.io-browsers": "^1.0.0",
     "strip-loader": "0.1.2",
     "text-blob-builder": "0.0.1",


### PR DESCRIPTION
So that the call to the `has-binary` method can be skipped. Usage:

```
// with binary data
socket.binary(true).emit("binary", obj);

// without binary data
socket.binary(false).emit("string", obj);

// call to hasBin
socket.emit("guess", obj);
```


*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


