### PR TITLE
fix: fire an error event on middleware failure for non-root namespace

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -222,7 +222,10 @@ Socket.prototype.onclose = function (reason) {
  */
 
 Socket.prototype.onpacket = function (packet) {
-  if (packet.nsp !== this.nsp) return;
+  var sameNamespace = packet.nsp === this.nsp;
+  var rootNamespaceError = packet.type === parser.ERROR && packet.nsp === '/';
+
+  if (!sameNamespace && !rootNamespaceError) return;
 
   switch (packet.type) {
     case parser.CONNECT:

--- a/test/socket.js
+++ b/test/socket.js
@@ -158,4 +158,22 @@ describe('socket', function () {
       });
     });
   });
+
+  it('should fire an error event on middleware failure from main namespace', function (done) {
+    var socket = io('/foo', { forceNew: true, query: { 'fail': true } });
+    socket.on('error', function (err) {
+      expect(err).to.eql('Auth failed (main namespace)');
+      socket.disconnect();
+      done();
+    });
+  });
+
+  it('should fire an error event on middleware failure from custom namespace', function (done) {
+    var socket = io('/no', { forceNew: true });
+    socket.on('error', function (err) {
+      expect(err).to.eql('Auth failed (custom namespace)');
+      socket.disconnect();
+      done();
+    });
+  });
 });

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -25,6 +25,15 @@ server.of('/abc').on('connection', function (socket) {
   socket.emit('handshake', socket.handshake);
 });
 
+server.use(function (socket, next) {
+  if (socket.request._query.fail) return next(new Error('Auth failed (main namespace)'));
+  next();
+});
+
+server.of('/no').use(function (socket, next) {
+  next(new Error('Auth failed (custom namespace)'));
+});
+
 server.on('connection', function (socket) {
   // simple test
   socket.on('hi', function () {


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

In the following example:

```js
io.use((socket, next) => {
  next(new Error('Auth failed'));
});

// client-side
const socket = io('https://url/custom-namespace');

socket.on('error', (err) => {
  // event was not fired
});
```

The 'error' event wasn't fired on the custom namespace.

### New behaviour

The event is now fired.

### Other information (e.g. related issues)

Related:
- https://github.com/socketio/socket.io/issues/3089
- https://github.com/socketio/socket.io/issues/1934
- https://github.com/socketio/socket.io/issues/1888


