### PR TITLE
Make sure location host is on the origin

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -28,6 +28,9 @@ function url (uri, loc) {
   loc = loc || global.location;
   if (null == uri) uri = loc.protocol + '//' + loc.host;
 
+  // make sure host is on the origin
+  loc.host = loc.host.replace(/\/$/, '');
+
   // relative path support
   if ('string' === typeof uri) {
     if ('/' === uri.charAt(0)) {

--- a/test/socket.js
+++ b/test/socket.js
@@ -25,7 +25,7 @@ describe('socket', function () {
   });
 
   it('should connect if host ends with / (custom namespace)', function (done) {
-    let original = global.location.host;
+    var original = global.location.host;
     global.location.host = global.location.host + '/';
     var socket = io('/foo', { forceNew: true });
     socket.on('connect', function () {

--- a/test/socket.js
+++ b/test/socket.js
@@ -24,6 +24,19 @@ describe('socket', function () {
     });
   });
 
+  it('should connect if host ends with / (custom namespace)', function (done) {
+    let original = global.location.host;
+    global.location.host = global.location.host + '/';
+    var socket = io('/foo', { forceNew: true });
+    socket.on('connect', function () {
+      expect(socket.id).to.be.ok();
+      expect(socket.id).to.eql('/foo#' + socket.io.engine.id);
+      socket.disconnect();
+      global.location.host = original;
+      done();
+    });
+  });
+
   it('clears socket.id upon disconnection', function (done) {
     var socket = io({ forceNew: true });
     socket.on('connect', function () {


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [x] a code change that improves performance
* [ ] other

### Current behaviour
Given 
```
const settings = {
  host : 'localhost:1234/'
};

let socket = io(`${settings.host}/foo`);
```

returns a "Invalid namespace", it makes total sense, the namespace is `/foo` and not `//foo`, but I have seen this problem happen to often.  

### New behaviour
url parser will just make sure Location host does not end with `/` making sure namespace is clean.

### Other information (e.g. related issues)


