### PR TITLE
[dependency] Downgrade to base64-arraybuffer@0.1.4 (#1234)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "backo2": "1.0.2",
-    "base64-arraybuffer": "0.1.5",
+    "base64-arraybuffer": "0.1.4",
     "component-bind": "1.0.0",
     "component-emitter": "1.2.1",
     "debug": "~3.1.0",


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
### Current behaviour

Bug mentioned in #1234 will happen under IE8

### New behaviour

Bug mentioned in #1234 won't happen under IE8
