### PR TITLE
Fix reconnection after opening socket asynchronously

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -104,7 +104,7 @@ Socket.prototype.connect = function () {
   if (this.connected) return this;
 
   this.subEvents();
-  this.io.open(); // ensure open
+  if (!this.io.reconnecting) this.io.open(); // ensure open
   if ('open' === this.io.readyState) this.onopen();
   this.emit('connecting');
   return this;

--- a/test/connection.js
+++ b/test/connection.js
@@ -459,9 +459,7 @@ describe('connection', function () {
       var socket = manager.socket('/room1');
 
       setTimeout(() => {
-        manager.socket(
-          `/room2`,
-        );
+        manager.socket('/room2');
       }, delay);
     });
   }

--- a/test/connection.js
+++ b/test/connection.js
@@ -433,6 +433,37 @@ describe('connection', function () {
 
       var socket = manager.socket('/invalid');
     });
+
+    it('should still try to reconnect twice after opening another socket asynchronously', function (done) {
+      var manager = io.Manager(
+        `http://localhost:9823`,
+        { reconnect: true, reconnectionAttempts: 2 }
+      );
+      var delay = Math.floor(manager.reconnectionDelay() * manager.randomizationFactor() * 0.5);
+      delay = Math.max(delay, 10);
+
+      var reconnects = 0;
+      var cb = function () {
+        reconnects++;
+      };
+
+      manager.on('reconnect_attempt', cb);
+
+      manager.on('reconnect_failed', function () {
+        expect(reconnects).to.be(2);
+        socket.disconnect();
+        manager.close();
+        done();
+      });
+
+      var socket = manager.socket('/room1');
+
+      setTimeout(() => {
+        manager.socket(
+          `/room2`,
+        );
+      }, delay);
+    });
   }
 
   it('should emit date as string', function (done) {


### PR DESCRIPTION
### Fix reconnection after opening socket asynchronously

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

https://github.com/socketio/socket.io/issues/3358

Assume we want to open two sockets, `a` and `b`, in the same pool:

```
var manager = io.Manager(
  `http://localhost:9823`,
  { reconnect: true, reconnectionAttempts: 2 }
);

var a = manager.socket('/room1');

setTimeout(() => {
  var b = manager.socket(
    `/room2`,
  );
}, 500);
```

If the timeout is short enough (or the sockets are opened synchronously), the manager's `connect` will be called before `errorSub` is called, so readyState is `opening` and `b` won’t attempt to connect again.

But if the readyState is `closed`, `b` will try to connect, fail, and reset the `subs`, which include the reconnect timer. But since `reconnecting` is still true, this stops future reconnect attempts.

### New behaviour

New sockets will not attempt to connect as long as there is an outstanding reconnect timer (ie, `reconnecting` on the manager is true).

### Other information (e.g. related issues)

You could also reset `reconnecting` and maybe the `Backoff` object in `cleanup`, attempting to connect again immediately. But I wasn't sure whether this should reset the connection attempts or interact at all with `autoConnect`.