### PR TITLE
Update debug to 4.1.1 (latest)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "base64-arraybuffer": "0.1.5",
     "component-bind": "1.0.0",
     "component-emitter": "1.2.1",
-    "debug": "~3.1.0",
+    "debug": "~4.1.1",
     "engine.io-client": "~3.3.1",
     "has-binary2": "~1.0.2",
     "has-cors": "1.1.0",


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

This simply updates the version of `debug` being used to the latest version, in order to get security patches that were applied in 4.0.0.

This version drops support for Node 4 and 5, but that shouldn't be an issue here since this is a client asset, not a server asset.

