### PR TITLE
Add volatile messages

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -42,6 +42,7 @@
     - [socket.on(eventName, callback)](#socketoneventname-callback)
     - [socket.compress(value)](#socketcompressvalue)
     - [socket.binary(value)](#socketbinaryvalue)
+    - [socket.volatile(value)](#socketvolatilevalue)
     - [socket.close()](#socketclose)
     - [socket.disconnect()](#socketdisconnect)
     - [Event: 'connect'](#event-connect)
@@ -533,6 +534,17 @@ Specifies whether the emitted data contains binary. Increases performance when s
 
 ```js
 socket.binary(false).emit('an event', { some: 'data' });
+```
+
+#### socket.volatile(value)
+
+  - `value` _(Boolean)_
+  - **Returns** `Socket`
+
+Specifies whether the emitted data will be dropped when this client is not ready to send messages. Can be `true` or `false`.
+
+```js
+socket.volatile(true).emit('an event', { some: 'data' });
 ```
 
 #### socket.close()

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -157,7 +157,7 @@ Socket.prototype.emit = function (ev) {
 
   if (this.connected) {
     this.packet(packet);
-  } else {
+  } else if (!this.flags.volatile) {
     this.sendBuffer.push(packet);
   }
 
@@ -434,5 +434,18 @@ Socket.prototype.compress = function (compress) {
 
 Socket.prototype.binary = function (binary) {
   this.flags.binary = binary;
+  return this;
+};
+
+/**
+ * Sets the volatile flag
+ *
+ * @param {Boolean} whether the emitted data is volatile
+ * @returns {Socket} self
+ * @api public
+ */
+
+Socket.prototype.volatile = function (volatile) {
+  this.flags.volatile = volatile;
   return this;
 };


### PR DESCRIPTION
### The kind of change this PR does introduce
- A new feature
- An update to the documentation

### Current behaviour
If the server went down, the client keeps backing failed messages, so when the server comes back online, it will be overloaded by unneeded messages.

### New behaviour
Add `socket.volatile()` to specify emitted data can be dropped if the connection is not ready to send.


### Other information (e.g. related issues)
Related issues:
- Add notion of volatile message to the client - [socketio/socket.io#2003](https://github.com/socketio/socket.io/issues/2003)
- Sending Volatile Messages - #283 
- Add/volatile support - #710

