### PR TITLE
Add CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 A standalone build of `socket.io-client` is exposed automatically by the
 socket.io server as `/socket.io/socket.io.js`. Alternatively you can
-serve the file `socket.io.js` found in the `dist` folder.
+serve the file `socket.io.js` found in the `dist` folder or include it via [CDN](https://cdn.jsdelivr.net/npm/socket.io-client@2/dist/socket.io.js).
 
 ```html
 <script src="/socket.io/socket.io.js"></script>


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/) to the readme as it is the same as downloading it but easier and faster.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [x] an update to the documentation
* [ ] a code change that improves performance
* [ ] other