### PR TITLE
Build Failing: Go Node V8 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
     "zuul-builder-webpack": "^1.2.0",
     "zuul-ngrok": "4.0.0"
   },
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "scripts": {
     "test": "gulp test"
   },


### PR DESCRIPTION
Fix the failing Travis build, go node v8 or higher!


*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


