### PR TITLE
[fix] Bump debug to version 3.1.0 (#1328)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "base64-arraybuffer": "0.1.5",
     "component-bind": "1.0.0",
     "component-emitter": "1.2.1",
-    "debug": "~4.1.0",
+    "debug": "~3.1.0",
     "engine.io-client": "~3.4.0",
     "has-binary2": "~1.0.2",
     "has-cors": "1.1.0",


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Failing to load the debug module in IE11

### New behaviour
Bump debug module to version 3.1.0 so it can load in IE11 

### Other information (e.g. related issues)
In the following commit they change "function" to "arrow function", but IE11 do not support arrow function. The commit has merged to debug@4.1.1 so bump debug module to version 3.1.0 will fix this issue

https://github.com/visionmedia/debug/commit/ba8a424d41e9dc6129e081ac3aa9715be6a45fbd#diff-b056c1ad802eb5041886154caaf3a3d4R157