### PR TITLE
Upgrade socket.io-parser@3.4.0, fix wrong browser environment detection in debug package

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "object-component": "0.0.3",
     "parseqs": "0.0.5",
     "parseuri": "0.0.5",
-    "socket.io-parser": "~3.3.0",
+    "socket.io-parser": "~3.4.0",
     "to-array": "0.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
`socket.io-parser` was upgraded inside `socket.io`, but not in this repo. 

`socket.io-parser@3.3.0` depends on an older, `debug@3.1.0`, which has an incorrect method of detecting `browser` or `node` environment (see: https://github.com/visionmedia/debug/commit/225c66f7198d2995e8232f9486aa9e087dc2a469#diff-1fdf421c05c1140f6d71444ea2b27638). This bump fixes the bug.


*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


