### PR TITLE
fix(typings): expose additional needed types

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -93,4 +93,4 @@ exports.connect = lookup;
  */
 
 export { Manager } from "./manager";
-export { lookup as io };
+export { lookup as io, Socket, SocketOptions };


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour

Needed types are not exposed by package index. These were exposed by `@types/socket.io-client`

### New behaviour

Package index re-exports additional types.

### Other information (e.g. related issues)

Caught while upgrading to the new major.