### PR TITLE
chore: export ManagerOptions

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -92,5 +92,5 @@ exports.connect = lookup;
  * @public
  */
 
-export { Manager } from "./manager";
+export { Manager, ManagerOptions } from "./manager";
 export { lookup as io, Socket, SocketOptions };


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] other

### Current behaviour

`ManagerOptions` is not exported in type definition.

### New behaviour

Exported.

### Other information (e.g. related issues)

Additionally I think types for options should be originally partial type.