### PR TITLE
fix: alias to export default io

### DIFF
--- a/wrapper.mjs
+++ b/wrapper.mjs
@@ -1,5 +1,5 @@
-import io from "./build/index.js";
+import {io as lookupIO} from "./build/index.js";
 
 export const Manager = io.Manager;
-export const io = io;
+export const io = lookupIO;
 export default io;


### PR DESCRIPTION
In webpack the io export failed because has already been declared


*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
An attempt is made to export io by default but it is declared in the import and as a constant and generates an error when exporting.
![image](https://user-images.githubusercontent.com/61970563/99516192-2fdc6580-298e-11eb-918c-6559b19ad531.png)

### New behaviour
Use an alias to export io

### Other information (e.g. related issues)


