### PR TITLE
fix(typings): export extraHeaders option

### DIFF
--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -181,7 +181,7 @@ interface EngineOptions {
    * Headers that will be passed for each request to the server (via xhr-polling and via websockets).
    * These values then can be used during handshake or for special proxies.
    */
-  extraHeaders?: {[header: string]: string};
+  extraHeaders?: { [header: string]: string };
 
   /**
    * Whether to include credentials (cookies, authorization headers, TLS

--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -178,6 +178,12 @@ interface EngineOptions {
   rejectUnauthorized: boolean;
 
   /**
+   * Headers that will be passed for each request to the server (via xhr-polling and via websockets).
+   * These values then can be used during handshake or for special proxies.
+   */
+  extraHeaders?: {[header: string]: string};
+
+  /**
    * Whether to include credentials (cookies, authorization headers, TLS
    * client certificates, etc.) with cross-origin XHR polling requests
    * @default false


### PR DESCRIPTION
related: https://github.com/socketio/socket.io-client/issues/1405


*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour
`extraHeaders` is not exported in type definition.

### New behavior
`extraHeaders` is **now** exported in type definition.

### Other information (e.g. related issues)


