### PR TITLE
Socket.opts should not be private and readonly

### DIFF
--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -279,7 +279,7 @@ export class Manager extends Emitter {
   _reconnecting: boolean;
 
   private readonly uri: string;
-  private readonly opts: Partial<ManagerOptions>;
+  opts: Partial<ManagerOptions>;
 
   private nsps: Record<string, Socket> = {};
   private subs: Array<ReturnType<typeof on>> = [];

--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -279,7 +279,7 @@ export class Manager extends Emitter {
   _reconnecting: boolean;
 
   private readonly uri: string;
-  opts: Partial<ManagerOptions>;
+  public opts: Partial<ManagerOptions>;
 
   private nsps: Record<string, Socket> = {};
   private subs: Array<ReturnType<typeof on>> = [];


### PR DESCRIPTION
As stated in the [documentation](https://socket.io/docs/v3/client-api/#With-query-option) query options can be set by setting `socket.io.opts` but `opts` was private and readonly.

Issue: https://github.com/socketio/socket.io-client/issues/1427

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

