### PR TITLE
Setting query was still not possible

### DIFF
--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -32,7 +32,7 @@ interface EngineOptions {
   /**
    * Any query parameters in our uri. Set from the URI passed when connecting
    */
-  query: Object;
+  query: {[key: string]: any};
 
   /**
    * `http.Agent` to use, defaults to `false` (NodeJS only)


### PR DESCRIPTION
Having type `Object` was still not possible to set values, e.g.:

```ts
    if (!this.socket.io.opts.query) {
      this.socket.io.opts.query = {};
    }

    this.socket.io.opts.query.token = 'abc123';
```

Results in error:
> Element implicitly has an 'any' type because expression of type '"token"' can't be used to index type 'Object'.


### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Other information (e.g. related issues)
When this is published to npm, please leave a comment, THANK YOU ! :)

