### PR TITLE
add `autoUnref` option to Manager.

### DIFF
--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -253,6 +253,13 @@ export interface ManagerOptions extends EngineOptions {
   autoConnect: boolean;
 
   /**
+   * weather we should unref the reconnect timer when it is
+   * create automatically
+   * @default false
+   */
+  autoUnref: boolean;
+
+  /**
    * the parser to use. Defaults to an instance of the Parser that ships with socket.io.
    */
   parser: any;
@@ -269,6 +276,10 @@ export class Manager extends Emitter {
    * @private
    */
   _autoConnect: boolean;
+  /**
+   * @private
+   */
+  _autoUnref: boolean;
   /**
    * @private
    */
@@ -338,6 +349,7 @@ export class Manager extends Emitter {
     this.encoder = new _parser.Encoder();
     this.decoder = new _parser.Decoder();
     this._autoConnect = opts.autoConnect !== false;
+    this._autoUnref = opts.autoUnref || false;
     if (this._autoConnect) this.open();
   }
 
@@ -749,6 +761,10 @@ export class Manager extends Emitter {
           }
         });
       }, delay);
+
+      if (this._autoUnref) {
+        timer.unref();
+      }
 
       this.subs.push(function subDestroy() {
         clearTimeout(timer);


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

If a client app is trying to reconnect, it leaves a `ref`d timer on the event loop which will prevent the program from exiting.

### New behaviour

With this change, if a user passes `autoUnref: true` the reconnect timer gets `unref`d each time it is created so that if it would have been the only thing preventing the event loop from exiting, the program exits.

### Other information (e.g. related issues)

This coordinates well with (but is in a sense independent of) this PR on engine.io-client:
https://github.com/socketio/engine.io-client/pull/652

Please note the `ref` and `unref` API mentioned there which is available on other Node internals such as timers, sockets, and servers.
