### PR TITLE
fix reconnectionAttempts not being honoured

### DIFF
--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -798,7 +798,6 @@ export class Manager<
   private onreconnect(): void {
     const attempt = this.backoff.attempts;
     this._reconnecting = false;
-    this.backoff.reset();
     this.emitReserved("reconnect", attempt);
   }
 }


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
When you currently set reconnectionAttempts to anything other than the default setting (Infinity), the client still tries to reconnect indefinitely.

### New behaviour
Attempts to reconnect stop after reaching the set reconnectionAttemps.

### Other information (e.g. related issues)
Caused by the backoff timer being reset in the onreconnect() event handler, causing backoff.attempts to always being reset to 0.
