### PR TITLE
fix: `auth` property on Socket is public

### DIFF
--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -57,7 +57,7 @@ export class Socket<
   public sendBuffer: Array<Packet> = [];
 
   private readonly nsp: string;
-  private readonly auth: object | ((cb: (data: object) => void) => void);
+  public readonly auth: object | ((cb: (data: object) => void) => void);
 
   private ids: number = 0;
   private acks: object = {};


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Currently the `auth` property on the `Socket` object is a `private` TypeScript property.
In the docs, it says that we can change the `auth` property. (see: https://socket.io/docs/v3/client-initialization/#auth)
But currently we can't in TypeScript.
![image](https://user-images.githubusercontent.com/25207499/111870495-63072380-8985-11eb-8526-89ec0162a086.png)

### New behaviour

Now the `auth` property is `public`, so we can update it.
