### PR TITLE
fix: update definition to match wrapper.mjs

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -101,3 +101,4 @@ exports.connect = lookup;
 
 export { Manager, ManagerOptions } from "./manager";
 export { lookup as io, Socket, SocketOptions };
+export default lookup;


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix

### Current behaviour
The file `wraper.mjs` is currently like:
```javascript
export default io;
```
![1617011194602](https://user-images.githubusercontent.com/15656042/112819050-bfb9bb00-90b6-11eb-89ed-1a183f854c34.jpg)

but `index.ts` does not export default lookup(io), so there is no type definition for this `export default` behaviour.
### New behaviour
add `export default lookup` to `index.ts`; when it's compiled, there will be a export default definitiion in the `build/index.d.ts` file.

![1617011090471](https://user-images.githubusercontent.com/15656042/112818811-7ec1a680-90b6-11eb-90ed-833a4b60eb8e.jpg)
