### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "./dist/socket.io.js": "./dist/socket.io.js",
     "./dist/socket.io.js.map": "./dist/socket.io.js.map",
     ".": {
+      "browser": "./dist/socket.io.js",
       "import": "./wrapper.mjs",
       "require": "./build/index.js"
     }


### PR DESCRIPTION
Fixes browser module resolution in webpack. See issue https://github.com/socketio/socket.io-client/issues/1457.


*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Webpack 5 uses the new exports field for module resolution. For web targets this results in the ES6 modules being used and this breaks compatibility with IE.

### New behaviour
By adding the `browser` field to the exports field, webpack will use the ES5 build.

### Other information (e.g. related issues)
https://github.com/socketio/socket.io-client/issues/1457

