### PR TITLE
Add missing closeOnBeforeunload option to types

### DIFF
--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -197,6 +197,12 @@ interface EngineOptions {
    * @default false
    */
   withCredentials: boolean;
+  
+  /**
+   * Whether to automatically close the connection whenever the beforeunload event is recieved.
+   * @default true
+   */
+  closeOnBeforeunload: boolean;
 }
 
 export interface ManagerOptions extends EngineOptions {

--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -199,7 +199,7 @@ interface EngineOptions {
   withCredentials: boolean;
   
   /**
-   * Whether to automatically close the connection whenever the beforeunload event is recieved.
+   * Whether to automatically close the connection whenever the beforeunload event is received.
    * @default true
    */
   closeOnBeforeunload: boolean;


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

The type closeOnBeforeunload was added to engine-io but it is not exposed in the typings.

### New behaviour

The typings should support he new option
