### PR TITLE
fix reconnection delay times not setting correctly

### DIFF
--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -360,9 +360,9 @@ export class Manager<
     this.opts = opts;
     this.reconnection(opts.reconnection !== false);
     this.reconnectionAttempts(opts.reconnectionAttempts || Infinity);
-    this.reconnectionDelay(opts.reconnectionDelay || 1000);
-    this.reconnectionDelayMax(opts.reconnectionDelayMax || 5000);
-    this.randomizationFactor(opts.randomizationFactor || 0.5);
+    this.reconnectionDelay(typeof(opts.reconnectionDelay)!=="undefined" ? opts.reconnectionDelay : 1000);
+    this.reconnectionDelayMax(typeof(opts.reconnectionDelayMax)!=="undefined" ? opts.reconnectionDelayMax : 5000);
+    this.randomizationFactor(typeof(opts.randomizationFactor)!=="undefined" ? opts.randomizationFactor: 0.5);
     this.backoff = new Backoff({
       min: this.reconnectionDelay(),
       max: this.reconnectionDelayMax(),


### PR DESCRIPTION
fix reconnection delay times not setting correctly

*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
```
    opts: {
      randomizationFactor: 0,
      reconnectionDelay: 1000,
      reconnectionDelayMax: 2000,
      path: '/socket.io',
      hostname: 'localhost',
      secure: false,
      port: '3000'
    },
    _reconnection: true,
    _reconnectionAttempts: Infinity,
    _reconnectionDelay: 1000,
    _reconnectionDelayMax: 2000,
    _randomizationFactor: 0.5,
    backoff: Backoff { ms: 1000, max: 2000, factor: 2, jitter: 0.5, attempts: 0 },
    _timeout: 20000,
```

### New behaviour
```
    opts: {
      randomizationFactor: 0,
      reconnectionDelay: 1000,
      reconnectionDelayMax: 2000,
      path: '/socket.io',
      hostname: 'localhost',
      secure: false,
      port: '3000'
    },
    _reconnection: true,
    _reconnectionAttempts: Infinity,
    _reconnectionDelay: 1000,
    _reconnectionDelayMax: 2000,
    _randomizationFactor: 0,
    backoff: Backoff { ms: 1000, max: 2000, factor: 2, jitter: 0, attempts: 0 },
    _timeout: 20000,
```

### Other information (e.g. related issues)

https://github.com/socketio/socket.io-client/issues/1231#issuecomment-887713661
