### PR TITLE
Add some types to the most common socket.io usage

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -27,19 +27,19 @@ const cache: Record<string, Manager> = (exports.managers = {});
  *
  * @public
  */
-function lookup(opts?: Partial<ManagerOptions & SocketOptions>): Socket;
-function lookup(
+function lookup<ListenEvents, EmitEvents>(opts?: Partial<ManagerOptions & SocketOptions>): Socket<ListenEvents, EmitEvents>;
+function lookup<ListenEvents, EmitEvents>(
   uri: string,
   opts?: Partial<ManagerOptions & SocketOptions>
-): Socket;
-function lookup(
+): Socket<ListenEvents, EmitEvents>;
+function lookup<ListenEvents, EmitEvents>(
   uri: string | Partial<ManagerOptions & SocketOptions>,
   opts?: Partial<ManagerOptions & SocketOptions>
-): Socket;
-function lookup(
+): Socket<ListenEvents, EmitEvents>
+function lookup<ListenEvents, EmitEvents>(
   uri: string | Partial<ManagerOptions & SocketOptions>,
   opts?: Partial<ManagerOptions & SocketOptions>
-): Socket {
+): Socket<ListenEvents, EmitEvents> {
   if (typeof uri === "object") {
     opts = uri;
     uri = undefined;

--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -318,7 +318,7 @@ export class Manager<
   private readonly uri: string;
   public opts: Partial<ManagerOptions>;
 
-  private nsps: Record<string, Socket> = {};
+  private nsps: Record<string, Socket<ListenEvents, EmitEvents>> = {};
   private subs: Array<ReturnType<typeof on>> = [];
   private backoff: Backoff;
   private _reconnection: boolean;
@@ -643,10 +643,10 @@ export class Manager<
    * @return {Socket}
    * @public
    */
-  public socket(nsp: string, opts?: Partial<SocketOptions>): Socket {
+  public socket(nsp: string, opts?: Partial<SocketOptions>): Socket<ListenEvents, EmitEvents> {
     let socket = this.nsps[nsp];
     if (!socket) {
-      socket = new Socket(this, nsp, opts);
+      socket = new Socket<ListenEvents, EmitEvents>(this, nsp, opts);
       this.nsps[nsp] = socket;
     }
 
@@ -659,7 +659,7 @@ export class Manager<
    * @param socket
    * @private
    */
-  _destroy(socket: Socket): void {
+  _destroy(socket: Socket<ListenEvents, EmitEvents>): void {
     const nsps = Object.keys(this.nsps);
 
     for (const nsp of nsps) {


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

Improved TypeScript support.

### Current behaviour

- You cannot specify TypeScript generics when calling `io()`, the return type is just `Socket`.
- You cannot specify TypeScript generics when calling `new Manager<T1, T2>().socket()`, the return type is just `Socket`.

### New behaviour

You can specify TypeScript generics in both those cases.

### Other information (e.g. related issues)