### PR TITLE
Fix re-export of `io` module

### DIFF
--- a/lib/browser-entrypoint.ts
+++ b/lib/browser-entrypoint.ts
@@ -1,1 +1,1 @@
-export * as io from "./index.js";
+export { io as default } from "./index";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -79,6 +79,19 @@ function lookup(
 
 export { protocol } from "socket.io-parser";
 
+// Manually create a merged object which acts as both the `lookup` function and
+// a 'namespace' on which the other functionality is exported and available.
+// This lets callers invoke the funtion directly as `io(...)` and also lets them
+// invoke subvalues on it, e.g. `io.connect(...)`. This allows the browser
+// entrypoint module to export this `io` as default, while still providing a
+// more general ES module export below.
+const io = Object.assign(lookup, {
+  Manager,
+  Socket,
+  io: lookup,
+  connect: lookup,
+});
+
 /**
  * Expose constructors for standalone build.
  *
@@ -90,6 +103,6 @@ export {
   ManagerOptions,
   Socket,
   SocketOptions,
-  lookup as io,
+  io,
   lookup as connect,
 };


### PR DESCRIPTION
The previous (CJS module) export semantics were of a *namespace*-style export, while the semantics introduced in c76d367 are of a single value exported as the default value instead. This broke downstream consumers who were using the namespace-style export, as documented at socketio/socket.io#4121. While the single default export should work fine (and might be preferable!), it's a breaking change, and appears to be an *accidental* breaking change, so this reverts to the previous semantics.

Accordingly, (re)introduce a manual 'namespace' by assigning the other exported value objects to the `lookup` function, thereby allowing it to be called directly, e.g. `io(...)`, or used to access the other values, e.g. `io.connect(...)`. Maintain the other existing exports so that the nice new ES module interface is still useful in its own right.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Accidentally switched away from namespace-style export.

### New behaviour

Revert to previous namespace-style export.

### Other information (e.g. related issues)

socketio/socket.io#4121 has the details and the history of my root-causing this.