### PR TITLE
fix: add types to exports field to be compatible with nodenext module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "node": "./build/esm-debug/index.js",
         "default": "./build/esm/index.js"
       },
-      "require": "./build/cjs/index.js"
+      "require": "./build/cjs/index.js",
+      "types": "./build/esm/index.d.ts"
     }
   },
   "types": "./build/esm/index.d.ts",


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Using `typescript@4.6.0-dev.20211225` and `"moduleResolution": "nodenext"` we are unable to resolve types of `socket.io-client`

### New behaviour

Make TypeScript successfully resolve types

### Other information (e.g. related issues)

See https://github.com/microsoft/TypeScript/issues/46770#issuecomment-966612103 for detail, in `nodenext` module resolution it requires a `types` field in `exports` with full filename including extension