### PR TITLE
fix: manager generic

### DIFF
--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -100,7 +100,7 @@ interface ManagerReservedEvents {
 export class Manager<
   ListenEvents extends EventsMap = DefaultEventsMap,
   EmitEvents extends EventsMap = ListenEvents
-> extends Emitter<{}, {}, ManagerReservedEvents> {
+> extends Emitter<ListenEvents, EmitEvents, ManagerReservedEvents> {
   /**
    * The Engine.IO client instance
    *


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
When creating a manager, an error occurs because it does not enter the emitter even if generic is added.

### New behaviour
It works well by handing over the generic received from the manager to the emitter.

### Other information (e.g. related issues)


