### PR TITLE
Fix: #1544, subsequent connections to previously used namespaces will multiplex

### DIFF
--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -468,7 +468,8 @@ export class Manager<
    * @param socket
    * @private
    */
-  _destroy(socket: Socket): void {
+  _destroy(closingSocket: Socket): void {
+    delete this.nsps[closingSocket.nsp];
     const nsps = Object.keys(this.nsps);
 
     for (const nsp of nsps) {

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -68,7 +68,7 @@ export class Socket<
   public receiveBuffer: Array<ReadonlyArray<any>> = [];
   public sendBuffer: Array<Packet> = [];
 
-  private readonly nsp: string;
+  public readonly nsp: string;
 
   private ids: number = 0;
   private acks: object = {};


### PR DESCRIPTION
- Socket.nsp to `public readonly`
- Manager will remove the namespace'd socket upon socket disconnect, thus allowing subsequent connections to the same namespace to multiplex.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [x] a code change that improves performance (in rare cases)
* [ ] other

### Current behaviour
Details here: https://github.com/socketio/socket.io-client/issues/1544
TLDR:  if a namespace calls `socket.disconnect();` then later a _new_ instance connects to the same `namespace`, a whole new connection will be made instead of multiplexing.

### New behaviour
When a socket on a namespace is disconnected, the manager will remove it from it's internal `nsp` Record. Thus subsequent connects will no longer create a new manager.

This will also help with performance for use cases where dynamic namespaces are used, which could create an infinite number of managers and socket instances in their `nsp` Record.

> NOTE: The current behavior where a new manager is created if a client attempts to make multiple _active_ connections to the same `namespace` is still present.

### Other information (e.g. related issues)
https://github.com/socketio/socket.io-client/issues/1514
https://github.com/socketio/socket.io-client/issues/1364
https://github.com/socketio/socket.io-client/issues/866
https://github.com/socketio/socket.io/issues/1956

