### PR TITLE
clearTimeout should be called from the same scope as setTimeout

### DIFF
--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -129,6 +129,7 @@ export class Manager<
   // @ts-ignore
   private backoff: Backoff;
   private setTimeoutFn: typeof setTimeout;
+  private clearTimeoutFn: typeof clearTimeout;
   private _reconnection: boolean;
   private _reconnectionAttempts: number;
   private _reconnectionDelay: number;
@@ -363,8 +364,8 @@ export class Manager<
         timer.unref();
       }
 
-      this.subs.push(function subDestroy(): void {
-        clearTimeout(timer);
+      this.subs.push(() => {
+        this.clearTimeoutFn(timer);
       });
     }
 
@@ -606,8 +607,8 @@ export class Manager<
         timer.unref();
       }
 
-      this.subs.push(function subDestroy() {
-        clearTimeout(timer);
+      this.subs.push(() => {
+        this.clearTimeoutFn(timer);
       });
     }
   }


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

In nw.js environment, when socket.io-client is imported as ES module (supposed to run in node.js context of nw.js) I observe following unexpected behavior.
Client successfully establishes connection via WebSocket transport, messages can be exchanged well, ping/pong mechanism is working well, but after 20 seconds connection is getting dropped and re-established again. It happens every 20 seconds exactly.

When I change timeout option of manager to some other value, I see that connection is getting dropped after exactly this value. That made me think that monitoring timer is not getting stopped when connection is successfully established.

I found that nw.js has several JS contexts running and problem disappears when I enable mixed context mode of nw.js (https://docs.nwjs.io/en/latest/For%20Users/Advanced/JavaScript%20Contexts%20in%20NW.js/#mixed-context-mode)

After looking into source code, I found that socket.io-client is starting timer using manager.setTimeoutFn function which is set by engine.io-client. But timer is getting stopped by regular clearTimeout function from current scope.
When I change it to manager.clearTimeoutFn problem disappears.
It seems somehow timer is starting from one scope and is getting stopped by different scope, that's why it's not actually stopped.

When I import socket.io-client as html script (running in browser context), I don't see behaviour and it works as expected.

### New behaviour

Using manager.clearTimeoutFn to stop monitoring timer.

### Other information (e.g. related issues)

https://docs.nwjs.io/en/latest/For%20Users/Advanced/JavaScript%20Contexts%20in%20NW.js/ 

