### PR TITLE
fix: make sure to add / prefix to namespace name

### DIFF
--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -461,6 +461,9 @@ export class Manager<
    * @public
    */
   public socket(nsp: string, opts?: Partial<SocketOptions>): Socket {
+    if (nsp[0] !== "/") {
+      nsp = "/" + nsp;
+    }
     let socket = this.nsps[nsp];
     if (!socket) {
       socket = new Socket(this, nsp, opts);


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Trying to connect to a namespace without the slash prefix ends up with a decoder error (error occurs on the server side):

```
Error: invalid payload
    at Decoder.decodeString (/home/user/dojo/socket.io/node_modules/.pnpm/socket.io-parser@4.2.2/node_modules/socket.io-parser/build/cjs/index.js:223:23)
    at Decoder.add (/home/user/dojo/socket.io/node_modules/.pnpm/socket.io-parser@4.2.2/node_modules/socket.io-parser/build/cjs/index.js:126:27)
    at Client.ondata (/home/user/dojo/socket.io/node_modules/.pnpm/socket.io@4.6.1/node_modules/socket.io/dist/client.js:182:26)
    at Socket.emit (node:events:513:28)
    at Socket.onPacket (/home/user/dojo/socket.io/node_modules/.pnpm/engine.io@6.4.1/node_modules/engine.io/build/socket.js:116:22)
    at Polling.emit (node:events:513:28)
    at Polling.onPacket (/home/user/dojo/socket.io/node_modules/.pnpm/engine.io@6.4.1/node_modules/engine.io/build/transport.js:92:14)
    at callback (/home/user/dojo/socket.io/node_modules/.pnpm/engine.io@6.4.1/node_modules/engine.io/build/transports/polling.js:166:18)
    at Array.forEach (<anonymous>)
    at Polling.onData (/home/user/dojo/socket.io/node_modules/.pnpm/engine.io@6.4.1/node_modules/engine.io/build/transports/polling.js:172:45)
```

#### Client code

```javascript
const Manager = require("socket.io-client").Manager;
const manager = new Manager("http://127.0.0.1:3000");
const socket = manager.socket("/");

socket.on("connect", () => {
  console.log("Connected to /");
});

// `two` instead of `/two`
const socket2 = manager.socket("two");
socket2.on("connect", () => {
  console.log("Connected to `two`");
});
```

#### Server code
```javascript
const express = require("express");
const app = express();
const http = require("http");
const server = http.createServer(app);
const { Server } = require("socket.io");
const io = new Server(server, {
  cors: {
    origin: "*",
  },
});

app.get("/", (req, res) => {
  res.send("Hello world");
});

io.on("connect", (socket) => {
  socket.on("error", (err) => {
    console.error("Error happened on /: " + err.stack);
  });
  console.log("Connection to / namespace");
});

io.of("two", (socket) => {
  socket.on("error", (err) => {
    console.error("Error happened on `two`: " + err.stack);
  });
  console.log("Connection to `two` namespace");
});

server.listen(3000, "127.0.0.1", () => {
  console.log("Listening on http://127.0.0.1:3000");
});
```

### New behaviour

Slash automatically gets inserted as a prefix inside the `Manager.socket` function.
