### PR TITLE
Fix debug import

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,9 +1,9 @@
 import { url } from "./url.js";
 import { Manager, ManagerOptions } from "./manager.js";
 import { Socket, SocketOptions } from "./socket.js";
-import debugPkg from "debug"; // debug()
+import debugModule from "debug"; // debug()
 
-const debug = (debugPkg.default || debugPkg)("socket.io-client"); // debug()
+const debug = debugModule("socket.io-client"); // debug()
 
 /**
  * Managers cache.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,9 +1,9 @@
 import { url } from "./url.js";
 import { Manager, ManagerOptions } from "./manager.js";
 import { Socket, SocketOptions } from "./socket.js";
-import * as debugModule from "debug"; // debug()
+import * as debugPkg from "debug"; // debug()
 
-const debug = (debugModule.default || debugModule)("socket.io-client"); // esModuleInterop
+const debug = (debugPkg.default || debugPkg)("socket.io-client"); // esModuleInterop
 
 /**
  * Managers cache.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
 import { url } from "./url.js";
 import { Manager, ManagerOptions } from "./manager.js";
 import { Socket, SocketOptions } from "./socket.js";
-import * as debugPkg from "debug"; // debug()
+import debugPkg from "debug"; // debug()
 
 const debug = (debugPkg.default || debugPkg)("socket.io-client"); // debug()
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,8 +2,7 @@ import { url } from "./url.js";
 import { Manager, ManagerOptions } from "./manager.js";
 import { Socket, SocketOptions } from "./socket.js";
 import * as debugModule from "debug"; // debug()
-
-const debug = debugModule("socket.io-client"); // debug()
+const debug = (debugModule.default || debugModule)("socket.io-client") // esModuleInterop
 
 /**
  * Managers cache.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
 import { url } from "./url.js";
 import { Manager, ManagerOptions } from "./manager.js";
 import { Socket, SocketOptions } from "./socket.js";
-import debugModule from "debug"; // debug()
+import * as debugModule from "debug"; // debug()
 
 const debug = debugModule("socket.io-client"); // debug()
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,7 +2,8 @@ import { url } from "./url.js";
 import { Manager, ManagerOptions } from "./manager.js";
 import { Socket, SocketOptions } from "./socket.js";
 import * as debugModule from "debug"; // debug()
-const debug = (debugModule.default || debugModule)("socket.io-client") // esModuleInterop
+
+const debug = (debugModule.default || debugModule)("socket.io-client"); // esModuleInterop
 
 /**
  * Managers cache.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,7 @@ import { Manager, ManagerOptions } from "./manager.js";
 import { Socket, SocketOptions } from "./socket.js";
 import * as debugPkg from "debug"; // debug()
 
-const debug = (debugPkg.default || debugPkg)("socket.io-client"); // esModuleInterop
+const debug = (debugPkg.default || debugPkg)("socket.io-client"); // debug()
 
 /**
  * Managers cache.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
       "types": "./build/esm/index.d.ts",
       "import": {
         "node": "./build/esm-debug/index.js",
+        "development": "./build/esm-debug/index.js",
         "default": "./build/esm/index.js"
       },
       "require": "./build/cjs/index.js"


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix

### Current behaviour
esm-debug will not work on most environments.
![Screenshot 2023-06-01 21 39 13](https://github.com/socketio/socket.io-client/assets/876076/e725369f-2e73-43f4-9164-9c2eac360972)

This is a hidden problem in Vite, which uses the browser version from node_modules. The browser version has debug stripped, which is VERY undesirable as vite is primary used in dev, and in production a built version with debug code stripped out is compiled.

### New behaviour
esm-debug will work when called directly in node or via unpkg. 

### Other information (e.g. related issues)
https://github.com/socketio/socket.io/issues/4731
https://v2.vitejs.dev/config/#resolve-conditions

unpkg's `?module` still wont work due to debug not being an ESM package, and unpackage not supporting ESM packages that import CJS. A fine solution would be to wrap it ourselves. We could also import the global by path, but I don't think we can rely on ESM to localize the global.

Confirmed working with: 
- `import io from '../node_modules/socket.io-client/build/esm-debug/index.js'`
- `import io from 'socket.io-client'`
- `import io from 'socket.io-client'` // TS with esModuleInterop

# StackBlitz

- [TS Sandbox with patched distributables](https://stackblitz.com/edit/pr-1585-socket-io-client?file=client.ts%3AL10)

# Before PR:

![Screenshot 2023-06-02 00 05 32](https://github.com/socketio/socket.io-client/assets/876076/e5519403-2aa7-4abe-8cde-867947a55bf0)

# After PR:

![Screenshot 2023-06-02 00 04 51](https://github.com/socketio/socket.io-client/assets/876076/aecb25ef-18b7-442d-9af7-4fec2c8c3986)
