### PR TITLE
fix(package.json): add types to `import` condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     ".": {
       "types": "./build/esm/index.d.ts",
       "import": {
+        "types": "./build/esm/index.d.ts",
         "node": "./build/esm-debug/index.js",
         "default": "./build/esm/index.js"
       },


### PR DESCRIPTION
Fix types resolution for modern environments
https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing


*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Modern environment that use `exports.import` won't resolve types properly

### New behaviour
The types are properly resolved

### Other information (e.g. related issues)


