### PR TITLE
fix: Update exports to include CJS types

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,16 +22,25 @@
     "./dist/socket.io.js": "./dist/socket.io.js",
     "./dist/socket.io.js.map": "./dist/socket.io.js.map",
     ".": {
-      "types": "./build/esm/index.d.ts",
       "import": {
+        "types": "./build/esm/index.d.ts",
         "node": "./build/esm-debug/index.js",
         "default": "./build/esm/index.js"
       },
-      "require": "./build/cjs/index.js"
+      "require": {
+        "types": "./build/cjs/index.d.ts",
+        "default": "./build/cjs/index.js"
+      }
     },
     "./debug": {
-      "import": "./build/esm-debug/index.js",
-      "require": "./build/cjs/index.js"
+      "import": {
+        "types": "./build/esm/index.d.ts",
+        "default": "./build/esm-debug/index.js",
+      },
+      "require": {
+        "types": "./build/cjs/index.d.ts",
+        "default": "./build/cjs/index.js"
+      }
     }
   },
   "types": "./build/esm/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "./debug": {
       "import": {
         "types": "./build/esm/index.d.ts",
-        "default": "./build/esm-debug/index.js",
+        "default": "./build/esm-debug/index.js"
       },
       "require": {
         "types": "./build/cjs/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "build/cjs/",
     "target": "es2018", // Node.js 10 (https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping)
     "module": "commonjs",
-    "declaration": false,
+    "declaration": true,
     "esModuleInterop": true
   },
   "include": [


### PR DESCRIPTION
*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix for #1589
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

Building a TypeScript project with `module: node16` or `nodenext` causes a compile error because of missing types. See #1589 for more details.

### New behaviour

With the changes in this PR, the package.json exports field includes `types` entries for the `import` and `require` specifiers, which enables TypeScript to find the types for both CJS and ESM usages.

In my testing, using the ESM types in the `require` entry did not work. It's possible I did something wrong, but because of this test result, I enabled declaration output for the CJS build so that the types are produced. This seemed simplest.

