### PR TITLE
Fix compilation on macOS

### DIFF
--- a/postcompile.sh
+++ b/postcompile.sh
@@ -4,7 +4,11 @@ cp ./support/package.esm.json ./build/esm/package.json
 
 cp -r ./build/esm/ ./build/esm-debug/
 
-sed -i '/debug(/d' ./build/esm/*.js
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' -e '/debug(/d' ./build/esm/*.js
+else
+    sed -i -e '/debug(/d' ./build/esm/*.js
+fi
 
 # for backward compatibility with `const socket = require("socket.io-client")(...)`
 echo -e '\nmodule.exports = lookup;' >> ./build/cjs/index.js


### PR DESCRIPTION
Refactor `postcompile.sh` script to use both GNU and BSD variants of `sed` command.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Other information (e.g. related issues)

Resolves #1615 .


